### PR TITLE
Custom options support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,29 @@ Usage: fastify [opts] <file>
   -P, --pretty-logs
       Prints pretty logs
 
+  -o, --options
+      Use custom options
+
   -h, --help
       Show this help message
+```
+
+If you want to use custom options, just export an options object with your route and run the cli command with the `--options` flag.
+```js
+// plugin.js
+module.exports = function (fastify, options, next) {
+  fastify.get('/', function (req, reply) {
+    reply.send({ hello: 'world' })
+  })
+  next()
+}
+
+module.exports.options = {
+  https: {
+    key: 'key',
+    cert: 'cert'
+  }
+}
 ```
 
 ## Contributing

--- a/cli.js
+++ b/cli.js
@@ -53,7 +53,7 @@ function runFastify (opts) {
     options.logger.stream = pretty
   }
 
-  const fastify = Fastify(options)
+  const fastify = Fastify(opts.options ? Object.assign(options, file.options) : options)
 
   fastify.register(file, function (err) {
     if (err) {
@@ -74,11 +74,12 @@ function runFastify (opts) {
 if (require.main === module) {
   start(minimist(process.argv.slice(2), {
     integer: ['port'],
-    boolean: ['pretty-logs'],
+    boolean: ['pretty-logs', 'options'],
     string: ['log-level'],
     alias: {
       port: 'p',
       help: 'h',
+      options: 'o',
       'log-level': 'l',
       'pretty-logs': 'P'
     },

--- a/examples/plugin-with-options.js
+++ b/examples/plugin-with-options.js
@@ -1,6 +1,15 @@
+'use strict'
+
 module.exports = function (fastify, options, next) {
   fastify.get('/', function (req, reply) {
     reply.send({ hello: 'world' })
   })
   next()
+}
+
+module.exports.options = {
+  https: {
+    key: 'key',
+    cert: 'cert'
+  }
 }

--- a/examples/plugin.js
+++ b/examples/plugin.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = function (fastify, options, next) {
+  fastify.get('/', function (req, reply) {
+    reply.send({ hello: 'world' })
+  })
+  next()
+}

--- a/help.txt
+++ b/help.txt
@@ -8,5 +8,8 @@ Usage: fastify [opts] <file>
   -P, --pretty-logs
       Prints pretty logs
 
+  -o, --options
+      Use custom options
+
   -h, --help
       Show this help message

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ test('should start the server', t => {
 
   cli.start({
     port: 3000,
-    _: ['./plugin.js']
+    _: ['./examples/plugin.js']
   })
 
   request({
@@ -23,4 +23,20 @@ test('should start the server', t => {
     t.deepEqual(JSON.parse(body), { hello: 'world' })
     cli.stop(0)
   })
+})
+
+test('should start fastify with custom options', t => {
+  t.plan(1)
+  // here the test should fail because of the wrong certificate
+  // or because the server is booted without the custom options
+  try {
+    cli.start({
+      port: 3000,
+      options: true,
+      _: ['./examples/plugin-with-options.js']
+    })
+    t.fail('Custom options')
+  } catch (e) {
+    t.pass('Custom options')
+  }
 })


### PR DESCRIPTION
As titled, usage:

`$ fastify -o plugin.js`

```js
'use strict'

module.exports = function (fastify, options, next) {
  fastify.get('/', function (req, reply) {
    reply.send({ hello: 'world' })
  })
  next()
}

module.exports.options = {
  https: {
    key: 'key',
    cert: 'cert'
  }
}
```