### PR TITLE
Export cli() so that we can call it from fastify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ jspm_packages
 
 # vim swap files
 *.swp
+
+# remove lock file
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "8"
   - "7"
   - "6"
   - "5"

--- a/cli.js
+++ b/cli.js
@@ -77,7 +77,7 @@ function runFastify (opts) {
   }
 }
 
-if (require.main === module) {
+function cli () {
   start(minimist(process.argv.slice(2), {
     integer: ['port'],
     boolean: ['pretty-logs', 'options'],
@@ -97,4 +97,8 @@ if (require.main === module) {
   }))
 }
 
-module.exports = { start, stop, runFastify }
+if (require.main === module) {
+  cli()
+}
+
+module.exports = { start, stop, runFastify, cli }


### PR DESCRIPTION
So that in fastify we could have our own binary that just requires this and calls `cli()`.

The current approach we are using does not work on npm@5.