### PR TITLE
Add prefix. Refactor to run multiple tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Usage: fastify [opts] <file>
   -o, --options
       Use custom options
 
+  -p, --prefix
+      Set the prefix
+
   -h, --help
       Show this help message
 ```

--- a/cli.js
+++ b/cli.js
@@ -68,7 +68,7 @@ function runFastify (opts) {
     pluginOptions.prefix = opts.prefix
   }
 
-  fastify.register(file, opts, assert.ifError)
+  fastify.register(file, pluginOptions, assert.ifError)
 
   if (opts.address) {
     fastify.listen(opts.port, opts.address, listen)

--- a/cli.js
+++ b/cli.js
@@ -33,7 +33,7 @@ function start (opts) {
 
   assert(opts._.length === 1, 'Missing the file parameter')
 
-  runFastify(opts)
+  return runFastify(opts)
 }
 
 function stop (code) {
@@ -63,7 +63,12 @@ function runFastify (opts) {
 
   const fastify = Fastify(opts.options ? Object.assign(options, file.options) : options)
 
-  fastify.register(file, assert.ifError)
+  const pluginOptions = {}
+  if (opts.prefix) {
+    pluginOptions.prefix = opts.prefix
+  }
+
+  fastify.register(file, opts, assert.ifError)
 
   if (opts.address) {
     fastify.listen(opts.port, opts.address, listen)
@@ -75,6 +80,8 @@ function runFastify (opts) {
     assert.ifError(err)
     console.log(`Server listening on http://localhost:${fastify.server.address().port}`)
   }
+
+  return fastify
 }
 
 function cli () {
@@ -87,6 +94,7 @@ function cli () {
       help: 'h',
       options: 'o',
       address: 'a',
+      prefix: 'r',
       'log-level': 'l',
       'pretty-logs': 'P'
     },

--- a/help.txt
+++ b/help.txt
@@ -15,5 +15,8 @@ Usage: fastify [opts] <file>
   -o, --options
       Use custom options
 
+  -p, --prefix
+      Set the prefix
+
   -h, --help
       Show this help message

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "update-notifier": "^2.1.0"
   },
   "devDependencies": {
-    "fastify": "^0.17.0",
+    "fastify": "^0.28.2",
     "request": "^2.81.0",
     "standard": "^10.0.2",
     "tap": "^10.3.2"

--- a/test.js
+++ b/test.js
@@ -6,22 +6,27 @@ const request = require('request')
 const cli = require('./cli')
 
 test('should start the server', t => {
-  t.plan(4)
+  t.plan(5)
 
-  cli.start({
+  const fastify = cli.start({
     port: 3000,
     _: ['./examples/plugin.js']
   })
 
-  request({
-    method: 'GET',
-    uri: 'http://localhost:3000'
-  }, (err, response, body) => {
+  t.tearDown(() => fastify.close())
+
+  fastify.ready(err => {
     t.error(err)
-    t.strictEqual(response.statusCode, 200)
-    t.strictEqual(response.headers['content-length'], '' + body.length)
-    t.deepEqual(JSON.parse(body), { hello: 'world' })
-    cli.stop(0)
+
+    request({
+      method: 'GET',
+      uri: 'http://localhost:3000'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.deepEqual(JSON.parse(body), { hello: 'world' })
+    })
   })
 })
 
@@ -39,4 +44,30 @@ test('should start fastify with custom options', t => {
   } catch (e) {
     t.pass('Custom options')
   }
+})
+
+test('should start the server at the given prefix', t => {
+  t.plan(5)
+
+  const fastify = cli.start({
+    port: 3000,
+    _: ['./examples/plugin.js'],
+    prefix: '/api/hello'
+  })
+
+  t.tearDown(() => fastify.close())
+
+  fastify.ready(err => {
+    t.error(err)
+
+    request({
+      method: 'GET',
+      uri: 'http://localhost:3000/api/hello'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.deepEqual(JSON.parse(body), { hello: 'world' })
+    })
+  })
 })


### PR DESCRIPTION
Refactorize in order to return fastify instance. So the test can start and stop the instance and run multiple tests.

Add `prefix` command line parameter