### PR TITLE
Added argument length checker

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -49,6 +49,11 @@ function runFastify (opts) {
     stop(1)
   }
 
+  if (file.length !== 3) {
+    throw new Error('Plugin function should contain 3 arguments. Refer to ' +
+                    'documentation for more information.')
+  }
+
   const options = {
     logger: {
       level: opts['log-level']

--- a/examples/incorrect-plugin.js
+++ b/examples/incorrect-plugin.js
@@ -1,0 +1,12 @@
+'use strict'
+
+// This is a counter example. WILL NOT WORK!
+// You must have 3 arguments in your plugin function.
+// Reference examples/plugin.js or examples/plugin-with-options.js
+//   for a correct example of plugin declaration
+module.exports = function (fastify, next) {
+  fastify.get('/', function (req, reply) {
+    reply.send({ wont: 'work' })
+  })
+  next()
+}

--- a/test.js
+++ b/test.js
@@ -71,3 +71,17 @@ test('should start the server at the given prefix', t => {
     })
   })
 })
+
+test('should only accept plugin functions with 3 arguments', t => {
+  t.plan(1)
+
+  try {
+    cli.start({
+      port: 3000,
+      _: ['./examples/incorrect-plugin.js']
+    })
+    t.fail('Incorrect arguments')
+  } catch (e) {
+    t.pass('Incorrect arguments')
+  }
+})


### PR DESCRIPTION
Closes https://github.com/fastify/fastify/issues/262 

Checks the length of the function arguments in the plugin file. Throws an error if 3 are not provided.