### PR TITLE
Add async/await plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ You can easily run it with:
 ```bash
 $ fastify plugin.js
 ```
+You can use `async` functions too, and make your plugin more concise: 
+```js
+// async-await-plugin.js
+module.exports = async function (fastify, options) {
+  fastify.get('/', async function (req, reply) {
+    return { hello: 'world' }
+  })
+}
+```
 
 CLI options:
 ```bash

--- a/cli.js
+++ b/cli.js
@@ -52,9 +52,15 @@ function runFastify (opts) {
     return module.exports.stop(e)
   }
 
-  if (file.length !== 3) {
+  console.log(file.constructor.name)
+
+  if (file.length !== 3 && file.constructor.name === 'Function') {
     return module.exports.stop(new Error('Plugin function should contain 3 arguments. Refer to ' +
                     'documentation for more information.'))
+  }
+  if (file.length !== 2 && file.constructor.name === 'AsyncFunction') {
+    return module.exports.stop(new Error('Async/Await plugin function should contain 2 arguments.' +
+    'Refer to documentation for more information.'))
   }
 
   const options = {

--- a/examples/async-await-plugin.js
+++ b/examples/async-await-plugin.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = async function (fastify, options) {
+  fastify.get('/', async function (req, reply) {
+    return { hello: 'world' }
+  })
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "update-notifier": "^2.1.0"
   },
   "devDependencies": {
-    "fastify": "^0.28.2",
+    "fastify": "^0.30.2",
     "pre-commit": "^1.2.2",
     "request": "^2.81.0",
     "standard": "^10.0.2",

--- a/test.js
+++ b/test.js
@@ -165,6 +165,36 @@ test('should throw on parsing error', t => {
   })
 })
 
+test('should start the server with an async/await plugin', t => {
+  if (Number(process.versions.node[0]) < 7) {
+    t.pass('Skip because Node version < 7')
+    return t.end()
+  }
+
+  t.plan(5)
+
+  const fastify = cli.start({
+    port: 3000,
+    _: ['./examples/async-await-plugin.js']
+  })
+
+  t.tearDown(() => fastify.close())
+
+  fastify.ready(err => {
+    t.error(err)
+
+    request({
+      method: 'GET',
+      uri: 'http://localhost:3000'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.deepEqual(JSON.parse(body), { hello: 'world' })
+    })
+  })
+})
+
 test('should exit without error on help', t => {
   t.plan(1)
 


### PR DESCRIPTION
Addressing #16, I added a test to check the CLI against an async/await plugin, then I added the related example both in README and in the proper directory. I used fastify 0.30.2 to ensure I was working with the very last version of the framework, is it ok?

I had to rework the arity check too, I dont know if it's ok for you.