### PR TITLE
Move fastify from devDependency to dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Write and run a route with one single command!
 
 ## Install
 ```bash
-npm install fastify-cli --save
+npm install fastify-cli --global
 ```
 
 ## Usage
@@ -25,6 +25,8 @@ You can easily run it with:
 ```bash
 $ fastify plugin.js
 ```
+If fastify has been installed local to plugin.js that copy will be used instead of the global copy included with fastify-cli.
+
 You can use `async` functions too, and make your plugin more concise: 
 ```js
 // async-await-plugin.js

--- a/package.json
+++ b/package.json
@@ -33,13 +33,14 @@
     ]
   },
   "dependencies": {
+    "fastify": "^0.35.7",
     "minimist": "^1.2.0",
     "pino-colada": "^1.4.0",
     "pump": "^2.0.0",
+    "resolve-from": "^4.0.0",
     "update-notifier": "^2.1.0"
   },
   "devDependencies": {
-    "fastify": "^0.30.2",
     "pre-commit": "^1.2.2",
     "request": "^2.81.0",
     "standard": "^10.0.2",


### PR DESCRIPTION
This causes fastify to be installed as a dependency of fastify-cli, as
fastify will no longer provide a command-line utility.

See fastify/fastify#514 for discussion.