### PR TITLE
Add bodyLimit support through --body-limit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Usage: fastify [opts] <file>
   -h, --help
       Show this help message
 
+  --body-limit
+      Defines the maximum payload, in bytes, the server is allowed to accept
+
 ```
 
 If you want to use custom options, just export an options object with your route and run the cli command with the `--options` flag.

--- a/cli.js
+++ b/cli.js
@@ -91,6 +91,10 @@ function runFastify (opts) {
     }
   }
 
+  if (opts['body-limit']) {
+    options.bodyLimit = opts['body-limit']
+  }
+
   if (opts['pretty-logs']) {
     const pinoColada = PinoColada()
     options.logger.stream = pinoColada
@@ -119,7 +123,7 @@ function runFastify (opts) {
 
 function cli () {
   start(minimist(process.argv.slice(2), {
-    integer: ['port'],
+    integer: ['port', 'body-limit'],
     boolean: ['pretty-logs', 'options'],
     string: ['log-level', 'address'],
     alias: {

--- a/examples/plugin.js
+++ b/examples/plugin.js
@@ -4,5 +4,8 @@ module.exports = function (fastify, options, next) {
   fastify.get('/', function (req, reply) {
     reply.send({ hello: 'world' })
   })
+  fastify.post('/', function (req, reply) {
+    reply.send({ hello: 'world' })
+  })
   next()
 }

--- a/help.txt
+++ b/help.txt
@@ -23,3 +23,6 @@ Usage: fastify [opts] <file>
 
   -h, --help
       Show this help message
+
+  --body-limit
+      Defines the maximum payload, in bytes, the server is allowed to accept

--- a/test.js
+++ b/test.js
@@ -224,3 +224,42 @@ test('should throw the right error on require file', t => {
     _: ['./test_data/undefinedVariable.js']
   })
 })
+
+test('should respond 413 - Payload too large', t => {
+  t.plan(5)
+
+  const bodyTooLarge = '{1: 11}'
+  const bodySmaller = '{1: 1}'
+
+  const fastify = cli.start({
+    port: 3000,
+    'body-limit': bodyTooLarge.length + 2 - 1,
+    _: ['./examples/plugin.js']
+  })
+
+  t.tearDown(() => fastify.close())
+
+  fastify.ready(err => {
+    t.error(err)
+
+    request({
+      method: 'POST',
+      uri: 'http://localhost:3000',
+      body: bodyTooLarge,
+      json: true
+    }, (err, response) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 413)
+    })
+
+    request({
+      method: 'POST',
+      uri: 'http://localhost:3000',
+      body: bodySmaller,
+      json: true
+    }, (err, response) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+    })
+  })
+})


### PR DESCRIPTION
As requested by myself in #43, I added support for [`bodyLimit` parameter](https://github.com/fastify/fastify/blob/master/docs/Factory.md#bodylimit) passed to the fastify factory through the `--body-limit` option. No default value is set, since fastify has already its default value.

I added the keyword `body-limit` to the `minimist` options in the `integer` array, for coherency, even though `minimist` does not do anything at all with the `integer` key (as we can see from [its documentation](https://github.com/substack/minimist#var-argv--parseargsargs-opts))
Does it have any sense for the `integer` key to exists in the `minimist` options?
