### PR TITLE
Update scripts and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/) [![Build Status](https://travis-ci.org/fastify/fastify-cli.svg?branch=master)](https://travis-ci.org/fastify/fastify-cli) [![Greenkeeper badge](https://badges.greenkeeper.io/fastify/fastify-cli.svg)](https://greenkeeper.io/)
 
-Command line tools for [fastify](https://github.com/mcollina/fastify).
+Command line tools for [Fastify](https://github.com/fastify/fastify).
 Generate, write and run an application with one single command!
 
 ## Install
@@ -99,7 +99,7 @@ Otherwise, `fastify-cli` will use the version of Fastify included within `fastif
 ### generate
 
 `fastify-cli` can also help with generating some project scaffolding to
-kickstart the development of your next fastify application. To use it:
+kickstart the development of your next Fastify application. To use it:
 
 1. `mkdir yourapp`
 2. `cd yourapp`
@@ -107,13 +107,22 @@ kickstart the development of your next fastify application. To use it:
 4. `fastify generate`
 5. `npm install`
 
-The sample code offers you three npm tasks:
+The sample code offers you four npm tasks:
 
 * `npm start` - starts the application
-* `npm run colada` - starts the application with
+* `npm run dev` - starts the application with
   [`pino-colada`](https://github.com/lrlna/pino-colada) pretty logging
   (not suitable for production)
 * `npm test` - runs the tests
+* `npm run lint` - runs the linter and automatically fixes the errors
+
+You will find three different folders:
+- `plugins`: the folder where you will place all your custom plugins
+- `services`: the folder where you will declare all your endpoints
+- `test`: the folder where you will declare all your test
+
+Finally there will be an `app.js` file, which is your entry point.
+It is a standard Fastify plugin and you will not need to add the `listen` method to run the server, just run it with one of the scripts above.
 
 ## Contributing
 If you feel you can help in any way, be it with examples, extra testing, or new features please open a pull request or open an issue.
@@ -122,7 +131,7 @@ The code follows the Standard code style.
 [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
 
 ## License
-**[MIT](https://github.com/delvedor/fastify-cli/blob/master/LICENSE)**
+**[MIT](https://github.com/fastify/fastify-cli/blob/master/LICENSE)**
 
 *The software is provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and non infringement. In no event shall the authors or copyright holders be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the software or the use or other dealings in the software.*
 

--- a/app_template/services/README.md
+++ b/app_template/services/README.md
@@ -6,15 +6,15 @@ to independently deploy some of those.
 
 In this folder you should define all the services that define the routes
 of your web application.
-Each service is a [fastify
+Each service is a [Fastify
 plugin](https://www.fastify.io/docs/latest/Plugins/), it is
-encapsulated (it can have its own indipendent plugins) and it is
-typically stored in a file; be carefult to group your routes logically,
+encapsulated (it can have its own independent plugins) and it is
+typically stored in a file; be careful to group your routes logically,
 e.g. all `/users` routes in a `users.js` file. We have added
 a `root.js` file for you with a '/' root added.
 
 If a single file become too large, create a folder and add a `index.js` file there:
-this file must be a fastify plugin, and it will be loaded automatically
+this file must be a Fastify plugin, and it will be loaded automatically
 by the application. You can now add as many files as you want inside that folder.
 In this way you can create complex services within a single monolith,
 and eventually extract them.

--- a/generate.js
+++ b/generate.js
@@ -30,9 +30,10 @@ function generate (dir, log, cb) {
       return cb(err)
     }
 
-    pkg.scripts.test = 'standard && tap test/*/*.test.js'
+    pkg.scripts.test = 'standard && tap test/*.test.js test/**/*.test.js test/**/**/*.test.js'
     pkg.scripts.start = 'fastify start app.js'
-    pkg.scripts.colada = 'fastify start -l info -P app.js'
+    pkg.scripts.dev = 'fastify start -l info -P app.js'
+    pkg.scripts.lint = 'standard --fix'
 
     pkg.dependencies = Object.assign(pkg.dependencies || {}, {
       'fastify': cliPkg.dependencies.fastify,

--- a/test/generate.js
+++ b/test/generate.js
@@ -69,7 +69,7 @@ function define (t) {
   })
 
   test('finish succesfully if package.json is there', (t) => {
-    t.plan(12 + Object.keys(expected).length * 2)
+    t.plan(13 + Object.keys(expected).length * 2)
 
     const pkgFile = path.join(workdir, 'package.json')
 
@@ -94,9 +94,10 @@ function define (t) {
         t.error(err)
 
         const pkg = JSON.parse(data)
-        t.equal(pkg.scripts.test, 'standard && tap test/*/*.test.js')
+        t.equal(pkg.scripts.test, 'standard && tap test/*.test.js test/**/*.test.js test/**/**/*.test.js')
         t.equal(pkg.scripts.start, 'fastify start app.js')
-        t.equal(pkg.scripts.colada, 'fastify start -l info -P app.js')
+        t.equal(pkg.scripts.dev, 'fastify start -l info -P app.js')
+        t.equal(pkg.scripts.lint, 'standard --fix')
         t.equal(pkg.dependencies['fastify-cli'], '^' + cliPkg.version)
         t.equal(pkg.dependencies['fastify'], cliPkg.dependencies.fastify)
         t.equal(pkg.dependencies['fastify-plugin'], cliPkg.devDependencies['fastify-plugin'])


### PR DESCRIPTION
I've updated the script section:
- Now the test runner path is `test/*.test.js test/**/*.test.js test/**/**/*.test.js`, because it can happen that a user writes some test in a deeper folder,  `/test/services/example/example.test.js` for example.
- Renamed `colada` to `dev`, is more clear the idea of the script and less criptic for the one who does not know `pino-colada`.
- Added `lint`, which basically is `standard --fix`.

I've also updated some part of the documentation and added a small summary of what `fastify generate` will build.