### PR TITLE
Pass options down to the autoloaded plugins

### DIFF
--- a/app_template/app.js
+++ b/app_template/app.js
@@ -12,13 +12,15 @@ module.exports = function (fastify, opts, next) {
   // those should be support plugins that are reused
   // through your application
   fastify.register(AutoLoad, {
-    dir: path.join(__dirname, 'plugins')
+    dir: path.join(__dirname, 'plugins'),
+    options: Object.assign({}, opts)
   })
 
   // This loads all plugins defined in services
   // define your routes in one of these
   fastify.register(AutoLoad, {
-    dir: path.join(__dirname, 'services')
+    dir: path.join(__dirname, 'services'),
+    options: Object.assign({}, opts)
   })
 
   // Make sure to call next when done


### PR DESCRIPTION
I'm not super convinced about this. Maybe we should rename `dir` to `autoload: { dir }` to avoid namespace clashing.

What do you think?