### PR TITLE
Fix docs on how to migrating out of fastify-cli start (#104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,12 +137,12 @@ const app = Fastify({
 })
 
 // Register your application as a normal plugin.
-fastify.register(require('./app.js'))
+app.register(require('./app.js'))
 
 // Start listening.
-fastify.listen(process.env.PORT || 3000, (err) => {
+app.listen(process.env.PORT || 3000, (err) => {
   if (err) {
-    fastify.log.error(err)
+    app.log.error(err)
     process.exit(1)
   }
 })


### PR DESCRIPTION
When i follow the instruction i get error:
```
ReferenceError: fastify is not defined
```

The right reference is the `app`, isn't it?

Here is the working snippet:
```
// Register your application as a normal plugin.
app.register(require('./app.js'))

// Start listening.
app.listen(process.env.PORT || 3000, (err) => {
  if (err) {
    app.log.error(err)
    process.exit(1)
  }
})
```