### PR TITLE
Fix boolean env variables override

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -7,7 +7,7 @@ const {
 const chalk = require('chalk')
 const path = require('path')
 const generify = require('generify')
-const minimist = require('minimist')
+const argv = require('yargs-parser')
 const templatedir = path.join(__dirname, 'app_template')
 const cliPkg = require('./package')
 
@@ -87,7 +87,7 @@ const colors = [
 ]
 
 function cli (args) {
-  const opts = minimist(args)
+  const opts = argv(args)
   generate(opts._[0] || process.cwd(), log, function (err) {
     if (err) {
       log('error', err.message)

--- a/package.json
+++ b/package.json
@@ -52,11 +52,11 @@
     "help-me": "^1.1.0",
     "is-docker": "^1.1.0",
     "make-promises-safe": "^1.1.0",
-    "minimist": "^1.2.0",
     "pino-colada": "^1.4.4",
     "pump": "^3.0.0",
     "resolve-from": "^4.0.0",
-    "update-notifier": "^2.4.0"
+    "update-notifier": "^2.4.0",
+    "yargs-parser": "^10.1.0"
   },
   "devDependencies": {
     "fastify-autoload": "^0.5.0",


### PR DESCRIPTION
Swapped minimist with yargs-parser because works better with prefixed env variables and is currently maintained.

This move will fix issue #110.