### PR TITLE
Normalize line endings in tests

### DIFF
--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -9,11 +9,11 @@ const rimraf = require('rimraf')
 const workdir = path.join(__dirname, 'workdir')
 const target = path.join(workdir, 'cli.test')
 
-rimraf(workdir, () => {
-  mkdirp.sync(workdir)
-  t.plan(1)
+t.plan(1)
 
-  execSync(`node cli.js generate ${target}`)
+rimraf.sync(workdir)
+mkdirp.sync(workdir)
 
-  t.pass()
-})
+execSync(`node cli.js generate ${target}`)
+
+t.pass()

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const t = require('tap')
+const { execSync } = require('child_process')
+const path = require('path')
+const mkdirp = require('mkdirp')
+const rimraf = require('rimraf')
+
+const workdir = path.join(__dirname, 'workdir')
+const target = path.join(workdir, 'cli.test')
+
+rimraf(workdir, () => {
+  mkdirp.sync(workdir)
+  t.plan(1)
+
+  execSync(`node cli.js generate ${target}`)
+
+  t.pass()
+})

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -125,7 +125,7 @@ function define (t) {
         readFile(file, function (err, data) {
           t.notOk(err)
           file = file.replace(workdir, '')
-          t.deepEqual(data.toString(), expected[file], file + ' matching')
+          t.deepEqual(data.toString().replace(/\r\n/g, '\n'), expected[file], file + ' matching')
         })
       })
   }


### PR DESCRIPTION
Previously, I sent a PR to `generify` to use environment eol (https://github.com/mcollina/generify/blob/master/generify.js#L69).

Now that we normalized all line endings (yes I stupidly pushed attributes file to origin to force normalize endings), the template in `fastify-cli` and the generated files differ in windows environment. 

So we either should normalize line endings here in tests via regexp or patch generify to not touch line endings.

I think the approach in this PR should be fine