### PR TITLE
generate <folder> change

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -81,8 +81,12 @@ function cli (args) {
     log('error', 'directory ' + opts._[0] + ' already exists')
     process.exit(1)
   }
+  if (opts._[0] === undefined) {
+    log('error', 'must specify a directory to \'fastify generate\'')
+    process.exit(1)
+  }
 
-  const dir = opts._[0] || process.cwd()
+  const dir = opts._[0]
 
   if (existsSync(path.join(dir, 'package.json'))) {
     log('error', 'a package.json file already exists in target directory')

--- a/generate.js
+++ b/generate.js
@@ -78,8 +78,10 @@ function cli (args) {
   const opts = argv(args)
 
   if (opts._[0] && existsSync(opts._[0])) {
-    log('error', 'directory ' + opts._[0] + ' already exists')
-    process.exit(1)
+    if (opts._[0] !== '.' && opts._[0] !== './') {
+      log('error', 'directory ' + opts._[0] + ' already exists')
+      process.exit(1)
+    }
   }
   if (opts._[0] === undefined) {
     log('error', 'must specify a directory to \'fastify generate\'')

--- a/help/generate.txt
+++ b/help/generate.txt
@@ -2,4 +2,4 @@ Usage: fastify generate <FOLDER>
 
 Sets up project with `npm init -y` and
 generates a sample Fastify project
-in the <FOLDER> or in the current working directory.
+in the <FOLDER>.

--- a/help/generate.txt
+++ b/help/generate.txt
@@ -2,4 +2,4 @@ Usage: fastify generate <FOLDER>
 
 Sets up project with `npm init -y` and
 generates a sample Fastify project
-in the <FOLDER>.
+in the <FOLDER>. Specify `.` to create files in the current working directory.

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -68,10 +68,18 @@ function define (t) {
     })
   })
 
-  test('errors if pkgfile exists', (t) => {
+  test('errors if generate doesn\'t have <folder> arguments', (t) => {
     t.plan(2)
     exec('node generate.js', (err, stdout) => {
-      t.is('a package.json file already exists in target directory', stdout.toString().trim())
+      t.is('must specify a directory to \'fastify generate\'', stdout.toString().trim())
+      t.is(1, err.code)
+    })
+  })
+
+  test('errors if folder exists', (t) => {
+    t.plan(2)
+    exec('node generate.js test', (err, stdout) => {
+      t.is('directory test already exists', stdout.toString().trim())
       t.is(1, err.code)
     })
   })

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -76,6 +76,22 @@ function define (t) {
     })
   })
 
+  test('errors if package.json exists when use generate .', (t) => {
+    t.plan(2)
+    exec('node generate.js .', (err, stdout) => {
+      t.is('a package.json file already exists in target directory', stdout.toString().trim())
+      t.is(1, err.code)
+    })
+  })
+
+  test('errors if package.json exists when use generate ./', (t) => {
+    t.plan(2)
+    exec('node generate.js ./', (err, stdout) => {
+      t.is('a package.json file already exists in target directory', stdout.toString().trim())
+      t.is(1, err.code)
+    })
+  })
+
   test('errors if folder exists', (t) => {
     t.plan(2)
     exec('node generate.js test', (err, stdout) => {


### PR DESCRIPTION
Change `<folder>` as a required param.
When I use `fastify generate` it will create files in current dir. It's ok when I am in the right dir, but It will waste time to delete files which generate created in the wrong dir.  
I thought it is necessary to make `<folder>` to be required, or add a tips in `fastify help` not just in `fastify help generate`