### PR TITLE
Remove lock files from app template .gitignore

### DIFF
--- a/templates/app/__gitignore
+++ b/templates/app/__gitignore
@@ -57,10 +57,6 @@ profile*
 *clinic*
 *flamegraph*
 
-# lock files
-yarn.lock
-package-lock.json
-
 # generated code
 examples/typescript-server.js
 test/types/index.js


### PR DESCRIPTION
Open source libs can benefit from ignoring lock files, but apps should commit them to source control.