### PR TITLE
Add command to print routes

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -11,6 +11,7 @@ const help = require('help-me')({
 const start = require('./start')
 const generate = require('./generate')
 const generateReadme = require('./generate-readme')
+const printRoutes = require('./print-routes')
 
 commist.register('start', start.cli)
 commist.register('generate', generate.cli)
@@ -19,6 +20,7 @@ commist.register('help', help.toStdout)
 commist.register('version', function () {
   console.log(require('./package.json').version)
 })
+commist.register('print-routes', printRoutes.cli)
 
 const res = commist.parse(process.argv.splice(2))
 

--- a/help/help.txt
+++ b/help/help.txt
@@ -3,6 +3,7 @@ Fastify command line interface available commands are:
   * start         start a server
   * generate      generate a new project
   * readme        generate a README.md for the plugin
+  * print-routes  prints the representation of the internal radix tree used by the router, useful for debugging.
   * version       the current fastify-cli version
   * help          help about commands
 

--- a/help/print-routes.txt
+++ b/help/print-routes.txt
@@ -1,0 +1,1 @@
+Usage: fastify print-routes <file>

--- a/print-routes.js
+++ b/print-routes.js
@@ -1,0 +1,116 @@
+#! /usr/bin/env node
+
+'use strict'
+
+require('dotenv').config()
+
+const assert = require('assert')
+const path = require('path')
+const fs = require('fs')
+const resolveFrom = require('resolve-from')
+const parseArgs = require('./args')
+const log = require('./log')
+
+let Fastify = null
+
+function loadModules (opts) {
+  try {
+    const basedir = path.resolve(process.cwd(), opts._[0])
+
+    Fastify = require(resolveFrom.silent(basedir, 'fastify') || 'fastify')
+  } catch (e) {
+    module.exports.stop(e)
+  }
+}
+
+function showHelp () {
+  console.log(fs.readFileSync(path.join(__dirname, 'help', 'print-routes.txt'), 'utf8'))
+  return module.exports.stop()
+}
+
+function printRoutes (args, cb) {
+  const opts = parseArgs(args)
+  if (opts.help) {
+    return showHelp()
+  }
+
+  if (opts._.length !== 1) {
+    console.error('Missing the required file parameter\n')
+    return showHelp()
+  }
+
+  // we start crashing on unhandledRejection
+  require('make-promises-safe')
+
+  loadModules(opts)
+
+  return runFastify(opts, cb)
+}
+
+function runFastify (opts, cb) {
+  const filePath = path.resolve(process.cwd(), opts._[0])
+  cb = cb || assert.ifError
+
+  if (!fs.existsSync(filePath)) {
+    return module.exports.stop(`${opts._[0]} doesn't exist within ${process.cwd()}`)
+  }
+
+  let file = null
+
+  try {
+    file = require(filePath)
+  } catch (e) {
+    return module.exports.stop(e)
+  }
+
+  if (file.length !== 3 && file.constructor.name === 'Function') {
+    return module.exports.stop(new Error('Plugin function should contain 3 arguments. Refer to ' +
+      'documentation for more information.'))
+  }
+  if (file.length !== 2 && file.constructor.name === 'AsyncFunction') {
+    return module.exports.stop(new Error('Async/Await plugin function should contain 2 arguments.' +
+      'Refer to documentation for more information.'))
+  }
+
+  const fastify = Fastify(opts.options)
+
+  const pluginOptions = {}
+  if (opts.prefix) {
+    pluginOptions.prefix = opts.prefix
+  }
+
+  fastify
+    .register(file, pluginOptions)
+    .ready((err) => {
+      if (err) {
+        return cb(err, fastify)
+      }
+
+      log('debug', fastify.printRoutes())
+
+      cb(null, fastify)
+    })
+
+  return fastify
+}
+
+function stop (message) {
+  if (message instanceof Error) {
+    console.log(message)
+    process.exit(1)
+  } else if (message) {
+    console.log(`Warn: ${message}`)
+    process.exit(1)
+  }
+  process.exit()
+}
+
+function cli (args) {
+  printRoutes(args)
+}
+
+module.exports = { cli, stop, printRoutes }
+
+if (require.main === module) {
+  cli(process.argv.slice(2))
+}

--- a/print-routes.js
+++ b/print-routes.js
@@ -19,21 +19,15 @@ function loadModules (opts) {
   }
 }
 
-function showHelp () {
-  showHelpForCommand('print-routes')
-
-  return module.exports.stop()
-}
-
 function printRoutes (args, cb) {
   const opts = parseArgs(args)
   if (opts.help) {
-    return showHelp()
+    return showHelpForCommand('print-routes')
   }
 
   if (opts._.length !== 1) {
     console.error('Missing the required file parameter\n')
-    return showHelp()
+    return showHelpForCommand('print-routes')
   }
 
   // we start crashing on unhandledRejection

--- a/print-routes.js
+++ b/print-routes.js
@@ -5,26 +5,23 @@
 require('dotenv').config()
 
 const assert = require('assert')
-const path = require('path')
-const fs = require('fs')
-const resolveFrom = require('resolve-from')
 const parseArgs = require('./args')
 const log = require('./log')
+const { exit, requireFastifyForModule, requireServerPluginFromPath, showHelpForCommand } = require('./util')
 
 let Fastify = null
 
 function loadModules (opts) {
   try {
-    const basedir = path.resolve(process.cwd(), opts._[0])
-
-    Fastify = require(resolveFrom.silent(basedir, 'fastify') || 'fastify')
+    Fastify = requireFastifyForModule(opts._[0]).module
   } catch (e) {
     module.exports.stop(e)
   }
 }
 
 function showHelp () {
-  console.log(fs.readFileSync(path.join(__dirname, 'help', 'print-routes.txt'), 'utf8'))
+  showHelpForCommand('print-routes')
+
   return module.exports.stop()
 }
 
@@ -48,28 +45,14 @@ function printRoutes (args, cb) {
 }
 
 function runFastify (opts, cb) {
-  const filePath = path.resolve(process.cwd(), opts._[0])
   cb = cb || assert.ifError
-
-  if (!fs.existsSync(filePath)) {
-    return module.exports.stop(`${opts._[0]} doesn't exist within ${process.cwd()}`)
-  }
 
   let file = null
 
   try {
-    file = require(filePath)
+    file = requireServerPluginFromPath(opts._[0])
   } catch (e) {
     return module.exports.stop(e)
-  }
-
-  if (file.length !== 3 && file.constructor.name === 'Function') {
-    return module.exports.stop(new Error('Plugin function should contain 3 arguments. Refer to ' +
-      'documentation for more information.'))
-  }
-  if (file.length !== 2 && file.constructor.name === 'AsyncFunction') {
-    return module.exports.stop(new Error('Async/Await plugin function should contain 2 arguments.' +
-      'Refer to documentation for more information.'))
   }
 
   const fastify = Fastify(opts.options)
@@ -95,18 +78,11 @@ function runFastify (opts, cb) {
 }
 
 function stop (message) {
-  if (message instanceof Error) {
-    console.log(message)
-    process.exit(1)
-  } else if (message) {
-    console.log(`Warn: ${message}`)
-    process.exit(1)
-  }
-  process.exit()
+  exit(message)
 }
 
 function cli (args) {
-  printRoutes(args)
+  printRoutes(args).close()
 }
 
 module.exports = { cli, stop, printRoutes }

--- a/start.js
+++ b/start.js
@@ -28,21 +28,15 @@ function loadModules (opts) {
   }
 }
 
-function showHelp () {
-  showHelpForCommand('start')
-
-  return module.exports.stop()
-}
-
 function start (args, cb) {
   const opts = parseArgs(args)
   if (opts.help) {
-    return showHelp()
+    return showHelpForCommand('start')
   }
 
   if (opts._.length !== 1) {
     console.error('Missing the required file parameter\n')
-    return showHelp()
+    return showHelpForCommand('start')
   }
 
   // we start crashing on unhandledRejection

--- a/start.js
+++ b/start.js
@@ -4,34 +4,33 @@
 
 require('dotenv').config()
 
-const path = require('path')
-const fs = require('fs')
 const assert = require('assert')
 const updateNotifier = require('update-notifier')
 const PinoColada = require('pino-colada')
 const pump = require('pump')
-const resolveFrom = require('resolve-from')
 const isDocker = require('is-docker')
 const listenAddressDocker = '0.0.0.0'
 const watch = require('./lib/watch')
 const parseArgs = require('./args')
+const { exit, requireFastifyForModule, requireServerPluginFromPath, showHelpForCommand } = require('./util')
 
 let Fastify = null
 let fastifyPackageJSON = null
 
 function loadModules (opts) {
   try {
-    const basedir = path.resolve(process.cwd(), opts._[0])
+    const { module: fastifyModule, pkg: fastifyPkg } = requireFastifyForModule(opts._[0])
 
-    Fastify = require(resolveFrom.silent(basedir, 'fastify') || 'fastify')
-    fastifyPackageJSON = require(resolveFrom.silent(basedir, 'fastify/package.json') || 'fastify/package.json')
+    Fastify = fastifyModule
+    fastifyPackageJSON = fastifyPkg
   } catch (e) {
     module.exports.stop(e)
   }
 }
 
 function showHelp () {
-  console.log(fs.readFileSync(path.join(__dirname, 'help', 'start.txt'), 'utf8'))
+  showHelpForCommand('start')
+
   return module.exports.stop()
 }
 
@@ -72,14 +71,7 @@ function start (args, cb) {
 }
 
 function stop (message) {
-  if (message instanceof Error) {
-    console.log(message)
-    process.exit(1)
-  } else if (message) {
-    console.log(`Warn: ${message}`)
-    process.exit(1)
-  }
-  process.exit()
+  exit(message)
 }
 
 function runFastify (args, cb) {
@@ -89,27 +81,12 @@ function runFastify (args, cb) {
 
   loadModules(opts)
 
-  const filePath = path.resolve(process.cwd(), opts._[0])
-
-  if (!fs.existsSync(filePath)) {
-    return module.exports.stop(`${opts._[0]} doesn't exist within ${process.cwd()}`)
-  }
-
   let file = null
 
   try {
-    file = require(filePath)
+    file = requireServerPluginFromPath(opts._[0])
   } catch (e) {
     return module.exports.stop(e)
-  }
-
-  if (file.length !== 3 && file.constructor.name === 'Function') {
-    return module.exports.stop(new Error('Plugin function should contain 3 arguments. Refer to ' +
-    'documentation for more information.'))
-  }
-  if (file.length !== 2 && file.constructor.name === 'AsyncFunction') {
-    return module.exports.stop(new Error('Async/Await plugin function should contain 2 arguments.' +
-    'Refer to documentation for more information.'))
   }
 
   const options = {

--- a/test/print-routes.test.js
+++ b/test/print-routes.test.js
@@ -78,13 +78,13 @@ test('should throw on parsing error', t => {
 })
 
 test('should print routes of server with an async/await plugin', t => {
-  t.plan(2)
-
   const nodeMajorVersion = process.versions.node.split('.').map(x => parseInt(x, 10))[0]
   if (nodeMajorVersion < 7) {
     t.pass('Skip because Node version < 7')
     return t.end()
   }
+
+  t.plan(2)
 
   const spy = sinon.spy()
   const command = proxyquire('../print-routes', {

--- a/test/print-routes.test.js
+++ b/test/print-routes.test.js
@@ -77,6 +77,23 @@ test('should throw on parsing error', t => {
   printRoutes.printRoutes(argv)
 })
 
+test('should exit without error on help', t => {
+  const exit = process.exit
+  process.exit = sinon.spy()
+
+  t.tearDown(() => {
+    process.exit = exit
+  })
+
+  const argv = ['-h', 'true']
+  printRoutes.printRoutes(argv)
+
+  t.ok(process.exit.called)
+  t.equal(process.exit.lastCall.args[0], undefined)
+
+  t.end()
+})
+
 test('should print routes of server with an async/await plugin', t => {
   const nodeMajorVersion = process.versions.node.split('.').map(x => parseInt(x, 10))[0]
   if (nodeMajorVersion < 7) {

--- a/test/print-routes.test.js
+++ b/test/print-routes.test.js
@@ -1,0 +1,103 @@
+'use strict'
+
+const proxyquire = require('proxyquire')
+const tap = require('tap')
+const sinon = require('sinon')
+
+const printRoutes = require('../print-routes')
+
+const test = tap.test
+
+test('should print routes', t => {
+  t.plan(2)
+
+  const spy = sinon.spy()
+  const command = proxyquire('../print-routes', {
+    './log': spy
+  })
+
+  command.printRoutes(['./examples/plugin.js'], (err, fastify) => {
+    if (err) t.error(err)
+
+    fastify.close(() => {
+      t.ok(spy.called)
+      t.ok(spy.calledWithMatch('debug', '└── / (GET|POST)\n'))
+    })
+  })
+})
+
+test('should warn on file not found', t => {
+  t.plan(1)
+
+  const oldStop = printRoutes.stop
+  t.tearDown(() => { printRoutes.stop = oldStop })
+  printRoutes.stop = function (message) {
+    t.ok(/.*not-found.js doesn't exist within/.test(message), message)
+  }
+
+  const argv = ['./data/not-found.js']
+  printRoutes.printRoutes(argv)
+})
+
+test('should only accept plugin functions with 3 arguments', t => {
+  t.plan(1)
+
+  const oldStop = printRoutes.stop
+  t.tearDown(() => { printRoutes.stop = oldStop })
+  printRoutes.stop = function (err) {
+    t.equal(err.message, 'Plugin function should contain 3 arguments. Refer to documentation for more information.')
+  }
+
+  printRoutes.printRoutes(['./test/data/incorrect-plugin.js'])
+})
+
+test('should throw on package not found', t => {
+  t.plan(1)
+
+  const oldStop = printRoutes.stop
+  t.tearDown(() => { printRoutes.stop = oldStop })
+  printRoutes.stop = function (err) {
+    t.ok(/Cannot find module 'unknown-package'/.test(err.message), err.message)
+  }
+
+  const argv = ['./test/data/package-not-found.js']
+  printRoutes.printRoutes(argv)
+})
+
+test('should throw on parsing error', t => {
+  t.plan(1)
+
+  const oldStop = printRoutes.stop
+  t.tearDown(() => { printRoutes.stop = oldStop })
+  printRoutes.stop = function (err) {
+    t.equal(err.constructor, SyntaxError)
+  }
+
+  const argv = ['./test/data/parsing-error.js']
+  printRoutes.printRoutes(argv)
+})
+
+test('should print routes of server with an async/await plugin', t => {
+  t.plan(2)
+
+  const nodeMajorVersion = process.versions.node.split('.').map(x => parseInt(x, 10))[0]
+  if (nodeMajorVersion < 7) {
+    t.pass('Skip because Node version < 7')
+    return t.end()
+  }
+
+  const spy = sinon.spy()
+  const command = proxyquire('../print-routes', {
+    './log': spy
+  })
+
+  const argv = ['./examples/async-await-plugin.js']
+  command.printRoutes(argv, (err, fastify) => {
+    if (err) t.error(err)
+
+    fastify.close(() => {
+      t.ok(spy.called)
+      t.ok(spy.calledWithMatch('debug', '└── / (GET)\n'))
+    })
+  })
+})

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -209,7 +209,7 @@ test('should start the server with an async/await plugin', t => {
   })
 })
 
-t.only('should exit without error on help', t => {
+test('should exit without error on help', t => {
   const exit = process.exit
   process.exit = sinon.spy()
 

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -209,17 +209,21 @@ test('should start the server with an async/await plugin', t => {
   })
 })
 
-test('should exit without error on help', t => {
-  t.plan(1)
+t.only('should exit without error on help', t => {
+  const exit = process.exit
+  process.exit = sinon.spy()
 
-  const oldStop = start.stop
-  t.tearDown(() => { start.stop = oldStop })
-  start.stop = function (err) {
-    t.equal(err, undefined)
-  }
+  t.tearDown(() => {
+    process.exit = exit
+  })
 
   const argv = ['-p', getPort(), '-h', 'true']
   start.start(argv)
+
+  t.ok(process.exit.called)
+  t.equal(process.exit.lastCall.args[0], undefined)
+
+  t.end()
 })
 
 test('should throw the right error on require file', t => {

--- a/util.js
+++ b/util.js
@@ -1,0 +1,72 @@
+const fs = require('fs')
+const path = require('path')
+
+const resolveFrom = require('resolve-from')
+
+function exit (message) {
+  if (message instanceof Error) {
+    console.log(message)
+    return process.exit(1)
+  } else if (message) {
+    console.log(`Warn: ${message}`)
+    return process.exit(1)
+  }
+
+  process.exit()
+}
+
+function requireFastifyForModule (modulePath) {
+  try {
+    const basedir = path.resolve(process.cwd(), modulePath)
+    const module = require(resolveFrom.silent(basedir, 'fastify') || 'fastify')
+    const pkg = require(resolveFrom.silent(basedir, 'fastify/package.json') || 'fastify/package.json')
+
+    return { module, pkg }
+  } catch (e) {
+    console.log('Warn: unable to load fastify module')
+    throw e
+  }
+}
+
+function isInvalidCallbackPlugin (plugin) {
+  return plugin.length !== 3 && plugin.constructor.name === 'Function'
+}
+
+function isInvalidAsyncPlugin (plugin) {
+  return plugin.length !== 2 && plugin.constructor.name === 'AsyncFunction'
+}
+
+function requireServerPluginFromPath (modulePath) {
+  const resolvedModulePath = path.resolve(process.cwd(), modulePath)
+
+  if (!fs.existsSync(resolvedModulePath)) {
+    throw new Error(`${resolvedModulePath} doesn't exist within ${process.cwd()}`)
+  }
+
+  const serverPlugin = require(resolvedModulePath)
+
+  if (isInvalidCallbackPlugin(serverPlugin)) {
+    throw new Error('Plugin function should contain 3 arguments. Refer to ' +
+      'documentation for more information.')
+  }
+
+  if (isInvalidAsyncPlugin(serverPlugin)) {
+    return new Error('Async/Await plugin function should contain 2 arguments.' +
+      'Refer to documentation for more information.')
+  }
+
+  return serverPlugin
+}
+
+function showHelpForCommand (commandName) {
+  const helpFilePath = path.join(__dirname, 'help', `${commandName}.txt`)
+
+  try {
+    console.log(fs.readFileSync(helpFilePath, 'utf8'))
+  } catch (e) {
+    console.log(`Warn: unable to get help for command "${commandName}"`)
+    throw e
+  }
+}
+
+module.exports = { exit, requireFastifyForModule, showHelpForCommand, requireServerPluginFromPath }

--- a/util.js
+++ b/util.js
@@ -23,8 +23,7 @@ function requireFastifyForModule (modulePath) {
 
     return { module, pkg }
   } catch (e) {
-    console.log('unable to load fastify module')
-    exit()
+    exit('unable to load fastify module')
   }
 }
 
@@ -66,7 +65,7 @@ function showHelpForCommand (commandName) {
     exit()
   } catch (e) {
     console.log(`unable to get help for command "${commandName}"`)
-    throw e
+    exit(e)
   }
 }
 

--- a/util.js
+++ b/util.js
@@ -64,8 +64,7 @@ function showHelpForCommand (commandName) {
     console.log(fs.readFileSync(helpFilePath, 'utf8'))
     exit()
   } catch (e) {
-    console.log(`unable to get help for command "${commandName}"`)
-    exit(e)
+    exit(`unable to get help for command "${commandName}"`)
   }
 }
 

--- a/util.js
+++ b/util.js
@@ -23,8 +23,8 @@ function requireFastifyForModule (modulePath) {
 
     return { module, pkg }
   } catch (e) {
-    console.log('Warn: unable to load fastify module')
-    throw e
+    console.log('unable to load fastify module')
+    exit()
   }
 }
 
@@ -63,8 +63,9 @@ function showHelpForCommand (commandName) {
 
   try {
     console.log(fs.readFileSync(helpFilePath, 'utf8'))
+    exit()
   } catch (e) {
-    console.log(`Warn: unable to get help for command "${commandName}"`)
+    console.log(`unable to get help for command "${commandName}"`)
     throw e
   }
 }


### PR DESCRIPTION
Hello,

I found myself needing a way to see a list (or tree) breakdown of all the routes my project had and thought it might be useful to have a command in `fastify-cli` that does just that.

This is essentially a CLI wrapper for `fastify.printRoutes`.

It behaves similarly to `fastify start` command except it relies on `fastify.ready()` rather than `fastify.listen()`, as such, there are a few function that are identical in both commands and could probably be abstracted and reused. If it seems reasonable, I could do it in the same PR. 

The reason I didn't write these abstractions is I preferred not to introduce too many changes to the project structure in order not to make this PR too invasive.