### PR TITLE
Debug mode for Fastify CLI Start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ test.sock
 # test artifacts
 test/workdir
 test/fixtures/*.js
+.vscode/launch.json

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ You can pass the following options via cli arguments, every options has the corr
 | Address to listen on | `-a` | `--address` | `FASTIFY_ADDRESS` |
 | Socket to listen on | `-s` | `--socket` | `FASTIFY_SOCKET` |
 | Log level (default to fatal) | `-l` | `--log-level` | `FASTIFY_LOG_LEVEL` |
+| Start fastify app in debug mode with nodejs inspector | `-d` | `--debug` | `FASTIFY_DEBUG` |
+| Set the inspector port (default: 9320) | `-I` | `--debug-port` | `FASTIFY_DEBUG_PORT` |
 | Prints pretty logs | `-P` | `--pretty-logs` | `FASTIFY_PRETTY_LOGS` |
 | Watch process.cwd() directory for changes, recursively; when that happens, the process will auto reload. | `-w` | `--watch` | `FASTIFY_WATCH` |
 | Ignore changes to the specified files or directories when watch is enabled. (e.g. `--ignore-watch='node_modules .git logs/error.log'` )|  | `--ignore-watch` | `FASTIFY_IGNORE_WATCH` |

--- a/args.js
+++ b/args.js
@@ -2,10 +2,10 @@
 
 const argv = require('yargs-parser')
 
-module.exports = function parseArgs (args) {
+module.exports = function parseArgs(args) {
   const parsedArgs = argv(args, {
-    number: ['port', 'body-limit', 'plugin-timeout'],
-    boolean: ['pretty-logs', 'options', 'watch'],
+    number: ['port', 'body-limit', 'plugin-timeout', 'debug-port'],
+    boolean: ['pretty-logs', 'options', 'watch', 'debug'],
     string: ['log-level', 'address', 'socket', 'prefix', 'ignore-watch'],
     envPrefix: 'FASTIFY_',
     alias: {
@@ -16,6 +16,8 @@ module.exports = function parseArgs (args) {
       address: ['a'],
       watch: ['w'],
       prefix: ['r'],
+      debug: ['d'],
+      'debug-port': ['I'],
       'log-level': ['l'],
       'pretty-logs': ['P'],
       'plugin-timeout': ['T']
@@ -38,6 +40,8 @@ module.exports = function parseArgs (args) {
     prettyLogs: parsedArgs.prettyLogs,
     options: parsedArgs.options,
     watch: parsedArgs.watch,
+    debug: parsedArgs.debug,
+    debugPort: parseArgs.debugPort,
     ignoreWatch: parsedArgs.ignoreWatch,
     logLevel: parsedArgs.logLevel,
     address: parsedArgs.address,

--- a/args.js
+++ b/args.js
@@ -27,7 +27,7 @@ module.exports = function parseArgs (args) {
       'pretty-logs': false,
       watch: false,
       debug: false,
-      debugPort: 9230,
+      debugPort: 9320,
       'ignore-watch': 'node_modules build dist .git bower_components logs',
       options: false,
       'plugin-timeout': 10 * 1000 // everything should load in 10 seconds

--- a/args.js
+++ b/args.js
@@ -2,9 +2,9 @@
 
 const argv = require('yargs-parser')
 
-module.exports = function parseArgs(args) {
+module.exports = function parseArgs (args) {
   const parsedArgs = argv(args, {
-    number: ['port', 'body-limit', 'plugin-timeout', 'debug-port'],
+    number: ['port', 'inspect-port', 'body-limit', 'plugin-timeout'],
     boolean: ['pretty-logs', 'options', 'watch', 'debug'],
     string: ['log-level', 'address', 'socket', 'prefix', 'ignore-watch'],
     envPrefix: 'FASTIFY_',
@@ -26,6 +26,8 @@ module.exports = function parseArgs(args) {
       'log-level': 'fatal',
       'pretty-logs': false,
       watch: false,
+      debug: false,
+      debugPort: 9230,
       'ignore-watch': 'node_modules build dist .git bower_components logs',
       options: false,
       'plugin-timeout': 10 * 1000 // everything should load in 10 seconds
@@ -41,7 +43,7 @@ module.exports = function parseArgs(args) {
     options: parsedArgs.options,
     watch: parsedArgs.watch,
     debug: parsedArgs.debug,
-    debugPort: parseArgs.debugPort,
+    debugPort: parsedArgs.debugPort,
     ignoreWatch: parsedArgs.ignoreWatch,
     logLevel: parsedArgs.logLevel,
     address: parsedArgs.address,

--- a/lib/watch/index.js
+++ b/lib/watch/index.js
@@ -15,7 +15,7 @@ const forkPath = path.join(__dirname, './fork.js')
 
 const emitter = new EventEmitter()
 
-let allStop = false
+const allStop = false
 let childs = []
 
 const stop = (watcher = null, err = null) => {
@@ -26,12 +26,11 @@ const stop = (watcher = null, err = null) => {
   childs = []
   if (err) { console.log(chalk.red(err)) }
   if (watcher) {
-    allStop = true
     watcher.close()
   }
 }
 
-const watch = function (args, ignoreWatch) {
+const watch = function (args, ignoreWatch, debugMode, debugPort) {
   process.on('uncaughtException', () => {
     stop()
     childs.push(run('restart'))
@@ -40,11 +39,11 @@ const watch = function (args, ignoreWatch) {
   const run = (event) => {
     const childEvent = { childEvent: event }
     const env = Object.assign({}, process.env, childEvent)
-    console.log("Forking");
-    const execArgv = [];
 
-    if (args.debug) {
-      execArgv.push('--inspect-brk=' + (args.debugPort || 9229))
+    const execArgv = []
+
+    if (debugMode) {
+      execArgv.push(`--inspect=${debugPort || 9229}`)
     }
 
     const _child = cp.fork(forkPath, args, {

--- a/lib/watch/index.js
+++ b/lib/watch/index.js
@@ -15,7 +15,7 @@ const forkPath = path.join(__dirname, './fork.js')
 
 const emitter = new EventEmitter()
 
-const allStop = false
+let allStop = false
 let childs = []
 
 const stop = (watcher = null, err = null) => {
@@ -26,6 +26,7 @@ const stop = (watcher = null, err = null) => {
   childs = []
   if (err) { console.log(chalk.red(err)) }
   if (watcher) {
+    allStop = true
     watcher.close()
   }
 }

--- a/lib/watch/index.js
+++ b/lib/watch/index.js
@@ -30,7 +30,7 @@ const stop = (watcher = null, err = null) => {
   }
 }
 
-const watch = function (args, ignoreWatch, debugMode, debugPort) {
+const watch = function (args, ignoreWatch) {
   process.on('uncaughtException', () => {
     stop()
     childs.push(run('restart'))
@@ -40,17 +40,10 @@ const watch = function (args, ignoreWatch, debugMode, debugPort) {
     const childEvent = { childEvent: event }
     const env = Object.assign({}, process.env, childEvent)
 
-    const execArgv = []
-
-    if (debugMode) {
-      execArgv.push(`--inspect=${debugPort || 9229}`)
-    }
-
     const _child = cp.fork(forkPath, args, {
       env: env,
       cwd: process.cwd(),
-      encoding: 'utf8',
-      execArgv
+      encoding: 'utf8'
     })
 
     _child.on('exit', function (code, signal) {

--- a/lib/watch/index.js
+++ b/lib/watch/index.js
@@ -45,7 +45,7 @@ const watch = function (args, ignoreWatch) {
       env: env,
       cwd: process.cwd(),
       encoding: 'utf8',
-      execArgv: []
+      execArgv: ['--inspect-brk']
     })
 
     _child.on('exit', function (code, signal) {

--- a/lib/watch/index.js
+++ b/lib/watch/index.js
@@ -41,11 +41,17 @@ const watch = function (args, ignoreWatch) {
     const childEvent = { childEvent: event }
     const env = Object.assign({}, process.env, childEvent)
     console.log("Forking");
+    const execArgv = [];
+
+    if (args.debug) {
+      execArgv.push('--inspect-brk=' + (args.debugPort || 9229))
+    }
+
     const _child = cp.fork(forkPath, args, {
       env: env,
       cwd: process.cwd(),
       encoding: 'utf8',
-      execArgv: ['--inspect-brk']
+      execArgv
     })
 
     _child.on('exit', function (code, signal) {

--- a/lib/watch/index.js
+++ b/lib/watch/index.js
@@ -40,10 +40,12 @@ const watch = function (args, ignoreWatch) {
   const run = (event) => {
     const childEvent = { childEvent: event }
     const env = Object.assign({}, process.env, childEvent)
+    console.log("Forking");
     const _child = cp.fork(forkPath, args, {
       env: env,
       cwd: process.cwd(),
-      encoding: 'utf8'
+      encoding: 'utf8',
+      execArgv: []
     })
 
     _child.on('exit', function (code, signal) {

--- a/start.js
+++ b/start.js
@@ -13,6 +13,7 @@ const listenAddressDocker = '0.0.0.0'
 const watch = require('./lib/watch')
 const parseArgs = require('./args')
 const { exit, requireFastifyForModule, requireServerPluginFromPath, showHelpForCommand } = require('./util')
+const inspector = require('inspector')
 
 let Fastify = null
 let fastifyPackageJSON = null
@@ -58,7 +59,7 @@ function start (args, cb) {
   })
 
   if (opts.watch) {
-    return watch(args, opts.ignoreWatch, opts.debug, opts.debugPort)
+    return watch(args, opts.ignoreWatch)
   }
 
   return runFastify(args, cb)
@@ -99,6 +100,10 @@ function runFastify (args, cb) {
     const pinoColada = PinoColada()
     options.logger.stream = pinoColada
     pump(pinoColada, process.stdout, assert.ifError)
+  }
+
+  if (opts.debug) {
+    inspector.open(opts.debugPort)
   }
 
   const fastify = Fastify(opts.options ? Object.assign(options, file.options) : options)

--- a/start.js
+++ b/start.js
@@ -14,11 +14,10 @@ const watch = require('./lib/watch')
 const parseArgs = require('./args')
 const { exit, requireFastifyForModule, requireServerPluginFromPath, showHelpForCommand } = require('./util')
 
-
 let Fastify = null
 let fastifyPackageJSON = null
 
-function loadModules(opts) {
+function loadModules (opts) {
   try {
     const { module: fastifyModule, pkg: fastifyPkg } = requireFastifyForModule(opts._[0])
 
@@ -29,7 +28,7 @@ function loadModules(opts) {
   }
 }
 
-function start(args, cb) {
+function start (args, cb) {
   const opts = parseArgs(args)
   if (opts.help) {
     return showHelpForCommand('start')
@@ -65,11 +64,11 @@ function start(args, cb) {
   return runFastify(args, cb)
 }
 
-function stop(message) {
+function stop (message) {
   exit(message)
 }
 
-function runFastify(args, cb) {
+function runFastify (args, cb) {
   const opts = parseArgs(args)
   opts.port = opts.port || process.env.PORT || 3000
   cb = cb || assert.ifError
@@ -129,14 +128,14 @@ function runFastify(args, cb) {
     fastify.listen(opts.port, wrap)
   }
 
-  function wrap(err) {
+  function wrap (err) {
     cb(err, fastify)
   }
 
   return fastify
 }
 
-function cli(args) {
+function cli (args) {
   start(args)
 }
 

--- a/start.js
+++ b/start.js
@@ -13,12 +13,12 @@ const listenAddressDocker = '0.0.0.0'
 const watch = require('./lib/watch')
 const parseArgs = require('./args')
 const { exit, requireFastifyForModule, requireServerPluginFromPath, showHelpForCommand } = require('./util')
-const inspector = require('inspector')
+
 
 let Fastify = null
 let fastifyPackageJSON = null
 
-function loadModules (opts) {
+function loadModules(opts) {
   try {
     const { module: fastifyModule, pkg: fastifyPkg } = requireFastifyForModule(opts._[0])
 
@@ -29,7 +29,7 @@ function loadModules (opts) {
   }
 }
 
-function start (args, cb) {
+function start(args, cb) {
   const opts = parseArgs(args)
   if (opts.help) {
     return showHelpForCommand('start')
@@ -65,11 +65,11 @@ function start (args, cb) {
   return runFastify(args, cb)
 }
 
-function stop (message) {
+function stop(message) {
   exit(message)
 }
 
-function runFastify (args, cb) {
+function runFastify(args, cb) {
   const opts = parseArgs(args)
   opts.port = opts.port || process.env.PORT || 3000
   cb = cb || assert.ifError
@@ -103,7 +103,11 @@ function runFastify (args, cb) {
   }
 
   if (opts.debug) {
-    inspector.open(opts.debugPort)
+    if (process.version.match(/v[0-6]\..*/g)) {
+      console.warn('Fastify debug mode not compatible with Node.js version < 6')
+    } else {
+      require('inspector').open(opts.debugPort)
+    }
   }
 
   const fastify = Fastify(opts.options ? Object.assign(options, file.options) : options)
@@ -125,14 +129,14 @@ function runFastify (args, cb) {
     fastify.listen(opts.port, wrap)
   }
 
-  function wrap (err) {
+  function wrap(err) {
     cb(err, fastify)
   }
 
   return fastify
 }
 
-function cli (args) {
+function cli(args) {
   start(args)
 }
 

--- a/start.js
+++ b/start.js
@@ -103,7 +103,7 @@ function runFastify (args, cb) {
 
   if (opts.debug) {
     if (process.version.match(/v[0-6]\..*/g)) {
-      console.warn('Fastify debug mode not compatible with Node.js version < 6')
+      stop('Fastify debug mode not compatible with Node.js version < 6')
     } else {
       require('inspector').open(opts.debugPort)
     }

--- a/start.js
+++ b/start.js
@@ -58,7 +58,7 @@ function start (args, cb) {
   })
 
   if (opts.watch) {
-    return watch(args, opts.ignoreWatch)
+    return watch(args, opts.ignoreWatch, opts.debug, opts.debugPort)
   }
 
   return runFastify(args, cb)

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -150,5 +150,5 @@ test('should respect default values', t => {
   t.is(parsedArgs.logLevel, 'fatal')
   t.is(parsedArgs.pluginTimeout, 10000)
   t.is(parsedArgs.debug, false)
-  t.is(parsedArgs.debugPort, 9230)
+  t.is(parsedArgs.debugPort, 9320)
 })

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -17,6 +17,8 @@ test('should parse args correctly', t => {
     '--prefix', 'FASTIFY_',
     '--plugin-timeout', '500',
     '--body-limit', '5242880',
+    '--debug', 'true',
+    '--debug-port', 1111,
     'app.js'
   ]
   const parsedArgs = parseArgs(argv)
@@ -33,7 +35,9 @@ test('should parse args correctly', t => {
     logLevel: 'info',
     prefix: 'FASTIFY_',
     pluginTimeout: 500,
-    bodyLimit: 5242880
+    bodyLimit: 5242880,
+    debug: true,
+    debugPort: 1111
   })
 })
 
@@ -52,6 +56,8 @@ test('should parse args with = assignment correctly', t => {
     '--prefix=FASTIFY_',
     '--plugin-timeout=500',
     '--body-limit=5242880',
+    '--debug=true',
+    '--debug-port', 1111,
     'app.js'
   ]
   const parsedArgs = parseArgs(argv)
@@ -68,7 +74,9 @@ test('should parse args with = assignment correctly', t => {
     logLevel: 'info',
     prefix: 'FASTIFY_',
     pluginTimeout: 500,
-    bodyLimit: 5242880
+    bodyLimit: 5242880,
+    debug: true,
+    debugPort: 1111
   })
 })
 
@@ -86,6 +94,8 @@ test('should parse env vars correctly', t => {
   process.env.FASTIFY_PREFIX = 'FASTIFY_'
   process.env.FASTIFY_BODY_LIMIT = '5242880'
   process.env.FASTIFY_PLUGIN_TIMEOUT = '500'
+  process.env.FASTIFY_DEBUG = 'true'
+  process.env.FASTIFY_DEBUG_PORT = '1111'
 
   t.teardown(function () {
     delete process.env.FASTIFY_PORT
@@ -99,6 +109,8 @@ test('should parse env vars correctly', t => {
     delete process.env.FASTIFY_PREFIX
     delete process.env.FASTIFY_BODY_LIMIT
     delete process.env.FASTIFY_PLUGIN_TIMEOUT
+    delete process.env.FASTIFY_DEBUG
+    delete process.env.FASTIFY_DEBUG_PORT
   })
 
   const parsedArgs = parseArgs([])
@@ -115,12 +127,14 @@ test('should parse env vars correctly', t => {
     port: 7777,
     prefix: 'FASTIFY_',
     socket: 'fastify.io.socket:9999',
-    pluginTimeout: 500
+    pluginTimeout: 500,
+    debug: true,
+    debugPort: 1111
   })
 })
 
 test('should respect default values', t => {
-  t.plan(7)
+  t.plan(9)
 
   const argv = [
     'app.js'
@@ -135,4 +149,6 @@ test('should respect default values', t => {
   t.is(parsedArgs.ignoreWatch, 'node_modules build dist .git bower_components logs')
   t.is(parsedArgs.logLevel, 'fatal')
   t.is(parsedArgs.pluginTimeout, 10000)
+  t.is(parsedArgs.debug, false)
+  t.is(parsedArgs.debugPort, 9230)
 })

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -442,7 +442,7 @@ test('should start the server listening on 0.0.0.0 when runing in docker', t => 
 })
 
 test('should start the server with watch options that the child process restart when directory changed', { skip: onTravis }, (t) => {
-  t.plan(6)
+  t.plan(5)
   const tmpjs = path.resolve(baseFilename + '.js')
 
   fs.writeFile(tmpjs, 'hello world', function (err) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->
#### Feature
With this PR you should be able to run a FastifyCLI-generated app with NodeJS inspector on a chosen port. The added flags are: `-d` (`--debug`) for enabling the debug mode and `-I` (`--debug-port`) for choosing a debug port. Works even in `--watch` mode.

#### What was done
- Programmatically call `inspector.open` right before running Fastify for the current process when debug mode active. Refs: https://nodejs.org/api/inspector.html
- Updated readme.md documentation

#### Contributions
This PR was created referring this issue: https://github.com/fastify/fastify-cli/issues/200. Thanks also to @pyxarez and @xtx1130. Feel free to contribute.

#### Checklist

- [-] run `npm run test` and `npm run benchmark`
- [-] tests and/or benchmarks are included
- [-] documentation is changed or added
- [-] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

