### PR TITLE
allow `--` for node process args

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ You can pass the following options via cli arguments, every options has the corr
 | Set the prefix | `-r` | `--prefix` | `FASTIFY_PREFIX` |
 | Set the plugin timeout | `-T` | `--plugin-timeout` | `FASTIFY_PLUGIN_TIMEOUT` |
 | Defines the maximum payload, in bytes,<br>the server is allowed to accept |  | `--body-limit` | `FASTIFY_BODY_LIMIT` |
+| Flag terminator, supply additional flags to be passed to the server instead of to fastify-ci. Example: fastify `start app.js --my flags` | `--` | n/a | n/a |
+      
 
 By default `fastify-cli` runs [`dotenv`](https://www.npmjs.com/package/dotenv), so it will load all the env variables stored in `.env` in your current working directory.
 

--- a/help/start.txt
+++ b/help/start.txt
@@ -43,5 +43,9 @@ Usage: fastify start [opts] <file>
   -T, --plugin-timeout
       The maximum amount of time that a plugin can take to load (default to 10 seconds).
 
+  --
+      Flag terminator, supply additional flags to be passed to the server instead
+      of to fastify-ci. Example: fastify start app.js --my flags
+
   -h, --help
       Show this help message

--- a/start.js
+++ b/start.js
@@ -36,7 +36,7 @@ function start (args, cb) {
     return showHelpForCommand('start')
   }
 
-  if (opts._.length !== 1) {
+  if (opts._.length < 1) {
     console.error('Missing the required file parameter\n')
     return showHelpForCommand('start')
   }
@@ -74,7 +74,7 @@ function runFastify (args, cb) {
   const opts = parseArgs(args)
   opts.port = opts.port || process.env.PORT || 3000
   cb = cb || assert.ifError
-
+  process.argv.push(...opts._.slice(1))
   loadModules(opts)
 
   let file = null

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -574,3 +574,16 @@ test('should throw on logger configuration module not found', t => {
     fastify.close()
   })
 })
+
+test('should pass pass args after -- to the server', t => {
+  const argv = ['-p', getPort(), './examples/plugin.js', '--', '--extra', 'good']
+  start.start(argv, function (err, fastify) {
+    t.error(err)
+    const serverArgv = process.argv.slice(2)
+    t.equal(serverArgv[0], '--extra')
+    t.equal(serverArgv[1], 'good')
+    fastify.close(() => {
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
allows for 

```sh
fastify start app.js -- --my-own-args cool
```

Works with and without `-w` flag

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
