### PR TITLE
add command to render interactive docs to the terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Fastify command line interface, available commands are:
   * generate      generate a new project
   * readme        generate a README.md for the plugin
   * version       the current fastify-cli version
+  * docs          starts an interactive terminal session to view the fastify docs for the fastify version installed. navigate with arrow keys
   * help          help about commands
 
 Launch 'fastify help [command]' to know more about the commands.
@@ -216,6 +217,14 @@ Finally there will be a new `README.md` file, which provides internal informatio
 + "lint": "standard --fix"
 },
 ```
+
+### docs
+
+`fastify-cli` allows you to view the documentation for fastify in your terminal. By default, fastify-cli attempts to render the documentation for the fastify version installed in the current working directory node_modules folder, however, if none are found, it should fall back to rendering the documentation for the version that fastify-cli depends on.
+
+The documentation is rendered using an interactive terminal session that you can navigate with your arrow keys.
+
+run `fastify docs` to get started.
 
 ## Contributing
 If you feel you can help in any way, be it with examples, extra testing, or new features please open a pull request or open an issue.

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Finally there will be a new `README.md` file, which provides internal informatio
 
 `fastify-cli` allows you to view the documentation for fastify in your terminal. By default, fastify-cli attempts to render the documentation for the fastify version installed in the current working directory node_modules folder, however, if none are found, it should fall back to rendering the documentation for the version that fastify-cli depends on.
 
-The documentation is rendered using an interactive terminal session that you can navigate with your arrow keys.
+The documentation is rendered using an interactive terminal session that you can navigate with your arrow keys by pressing the enter key to select documentation to view.
 
 run `fastify docs` to get started.
 

--- a/cli.js
+++ b/cli.js
@@ -12,10 +12,12 @@ const start = require('./start')
 const generate = require('./generate')
 const generateReadme = require('./generate-readme')
 const printRoutes = require('./print-routes')
+const renderDocs = require('./docs')
 
 commist.register('start', start.cli)
 commist.register('generate', generate.cli)
 commist.register('readme', generateReadme.cli)
+commist.register('docs', renderDocs)
 commist.register('help', help.toStdout)
 commist.register('version', function () {
   console.log(require('./package.json').version)

--- a/docs.js
+++ b/docs.js
@@ -1,0 +1,127 @@
+const blessed = require('blessed')
+const contrib = require('blessed-contrib')
+const walkup = require('walk-up')
+const fs = require('fs').promises
+const { join } = require('path')
+
+function findDocs () {
+  return new Promise((resolve, reject) => {
+    const searchDir = 'node_modules/fastify/docs'
+    walkup(process.cwd(), searchDir, (err, results) => {
+      if (err) {
+        return reject(err)
+      }
+
+      if (results.found) {
+        return resolve(join(results.path, searchDir))
+      } else {
+        walkup(__dirname, searchDir, (err, results) => {
+          if (err) {
+            return reject(err)
+          }
+
+          if (results.found) {
+            return resolve(join(results.path, searchDir))
+          } else {
+            return resolve()
+          }
+        })
+      }
+    })
+  })
+}
+
+async function renderDocs () {
+  const docsBase = await findDocs()
+
+  if (!docsBase) return console.error('Something went wrong finding docs... please report a bug! https://github.com/fastify/fastify-cli')
+
+  const fileNames = await fs.readdir(docsBase)
+  const docNames = fileNames.map(fileName => fileName.replace(/-/g, ' ').replace(/\.md$/, ''))
+
+  const fileContents = []
+  for (const fileName of fileNames) {
+    fileContents.push((await fs.readFile(join(docsBase, fileName))).toString('utf8'))
+  }
+
+  const screen = blessed.screen({
+    smartCSR: true
+  })
+
+  // eslint-disable-next-line
+  const grid = new contrib.grid({ rows: 12, cols: 12, screen: screen })
+
+  const list = grid.set(0, 0, 12, 3, blessed.list, {
+    label: 'Docs',
+    items: docNames,
+    keys: true,
+    vi: true,
+    mouse: true,
+    style: {
+      border: {
+        fg: 'green'
+      },
+      selected: {
+        fg: 'green',
+        bg: 'white'
+      }
+    }
+  })
+  list.select(0)
+  list.focus()
+
+  list.on('select', (el, selected) => {
+    markdown.setLabel(docNames[selected])
+    markdown.setMarkdown(fileContents[selected])
+    screen.render()
+  })
+
+  const markdown = grid.set(0, 3, 12, 9, contrib.markdown, {
+    label: docNames[0],
+    scrollable: true,
+    keys: true,
+    vi: true,
+    mouse: true,
+    style: {
+      border: {
+        fg: 'white'
+      }
+    },
+    alwaysScroll: true,
+    scrollbar: {
+      ch: ' ',
+      bg: 'blue'
+    }
+  })
+  markdown.setMarkdown(fileContents[0])
+
+  list.on('keypress', (el, e) => {
+    if (e.full === 'right') {
+      markdown.focus()
+      list.style.selected.fg = null
+      list.style.selected.bg = null
+      list.style.border.fg = 'white'
+      markdown.style.border.fg = 'green'
+      screen.render()
+    }
+  })
+
+  markdown.on('keypress', (el, e) => {
+    if (e.full === 'left') {
+      list.focus()
+      list.style.selected.fg = 'green'
+      list.style.selected.bg = 'white'
+      list.style.border.fg = 'green'
+      markdown.style.border.fg = 'white'
+      screen.render()
+    }
+  })
+
+  screen.render()
+
+  screen.key(['escape', 'q', 'C-c'], function (ch, key) {
+    return process.exit(0)
+  })
+}
+
+module.exports = renderDocs

--- a/docs.js
+++ b/docs.js
@@ -1,47 +1,21 @@
+'use strict'
+
 const blessed = require('blessed')
 const contrib = require('blessed-contrib')
-const walkup = require('walk-up')
-const fs = require('fs').promises
-const { join } = require('path')
+const fs = require('fs')
+const path = require('path')
 
-function findDocs () {
-  return new Promise((resolve, reject) => {
-    const searchDir = 'node_modules/fastify/docs'
-    walkup(process.cwd(), searchDir, (err, results) => {
-      if (err) {
-        return reject(err)
-      }
-
-      if (results.found) {
-        return resolve(join(results.path, searchDir))
-      } else {
-        walkup(__dirname, searchDir, (err, results) => {
-          if (err) {
-            return reject(err)
-          }
-
-          if (results.found) {
-            return resolve(join(results.path, searchDir))
-          } else {
-            return resolve()
-          }
-        })
-      }
-    })
-  })
-}
-
-async function renderDocs () {
-  const docsBase = await findDocs()
+function renderDocs () {
+  const docsBase = path.join(path.dirname(require.resolve('fastify')), 'docs')
 
   if (!docsBase) return console.error('Something went wrong finding docs... please report a bug! https://github.com/fastify/fastify-cli')
 
-  const fileNames = await fs.readdir(docsBase)
+  const fileNames = fs.readdirSync(docsBase)
   const docNames = fileNames.map(fileName => fileName.replace(/-/g, ' ').replace(/\.md$/, ''))
 
   const fileContents = []
   for (const fileName of fileNames) {
-    fileContents.push((await fs.readFile(join(docsBase, fileName))).toString('utf8'))
+    fileContents.push((fs.readFileSync(path.join(docsBase, fileName))).toString('utf8'))
   }
 
   const screen = blessed.screen({

--- a/help/docs.txt
+++ b/help/docs.txt
@@ -1,0 +1,7 @@
+Usage: fastify docs
+
+Starts an interactive terminal session to view the documentation for the fastify version installed.
+
+If no fastify version is found in the current work directory node_modules folder, the fastify version that the cli depends on is used for docs.
+
+Navigate with arrow keys.

--- a/help/docs.txt
+++ b/help/docs.txt
@@ -4,4 +4,4 @@ Starts an interactive terminal session to view the documentation for the fastify
 
 If no fastify version is found in the current work directory node_modules folder, the fastify version that the cli depends on is used for docs.
 
-Navigate with arrow keys.
+Navigate with arrow keys and pressing the enter key to select documentation to view.

--- a/help/help.txt
+++ b/help/help.txt
@@ -5,6 +5,7 @@ Fastify command line interface available commands are:
   * readme        generate a README.md for the plugin
   * print-routes  prints the representation of the internal radix tree used by the router, useful for debugging.
   * version       the current fastify-cli version
+  * docs          starts an interactive terminal session to view the fastify docs for the fastify version installed. navigate with arrow keys
   * help          help about commands
 
 Launch 'fastify help [command]' to learn more about each command.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "pino-colada": "^1.4.4",
     "pump": "^3.0.0",
     "resolve-from": "^4.0.0",
-    "walk-up": "^1.0.2",
     "yargs-parser": "^16.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     ]
   },
   "dependencies": {
+    "blessed": "^0.1.81",
+    "blessed-contrib": "^4.8.18",
     "chalk": "^2.4.2",
     "chokidar": "^2.1.5",
     "commist": "^1.0.0",
@@ -55,6 +57,7 @@
     "pino-colada": "^1.4.4",
     "pump": "^3.0.0",
     "resolve-from": "^4.0.0",
+    "walk-up": "^1.0.2",
     "yargs-parser": "^16.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds the ability for you to view the documentation for fastify in your terminal. By default, `fastify-cli` attempts to render the documentation for the fastify version installed in the current working directory node_modules folder, however, if none are found, it should fall back to rendering the documentation for the version that fastify-cli depends on.

The documentation is rendered using an interactive terminal session that you can navigate with your arrow keys.

run `fastify docs` to get started.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

Screenshots:

![Screenshot 2020-02-11 at 17 55 40](https://user-images.githubusercontent.com/6907399/74264151-179d3300-4cf8-11ea-89bf-5fe8a4818caf.png)
![Screenshot 2020-02-11 at 17 56 40](https://user-images.githubusercontent.com/6907399/74264161-1bc95080-4cf8-11ea-8dc3-d9e21752cdff.png)
![Screenshot 2020-02-11 at 17 56 50](https://user-images.githubusercontent.com/6907399/74264168-1cfa7d80-4cf8-11ea-8f2d-a9af361c9747.png)

