### PR TITLE
FEATURE/add-ts-module-start-support

### DIFF
--- a/examples/ts-plugin-with-options.js
+++ b/examples/ts-plugin-with-options.js
@@ -1,0 +1,15 @@
+'use strict'
+
+exports.default = function (fastify, options, next) {
+  fastify.get('/', function (req, reply) {
+    reply.send({ hello: 'world' })
+  })
+  next()
+}
+
+exports.options = {
+  https: {
+    key: 'key',
+    cert: 'cert'
+  }
+}

--- a/examples/ts-plugin.js
+++ b/examples/ts-plugin.js
@@ -1,0 +1,12 @@
+'use strict'
+
+exports.default = function (fastify, options, next) {
+  fastify.decorate('test', true)
+  fastify.get('/', function (req, reply) {
+    reply.send({ hello: 'world' })
+  })
+  fastify.post('/', function (req, reply) {
+    reply.send({ hello: 'world' })
+  })
+  next()
+}

--- a/start.js
+++ b/start.js
@@ -116,7 +116,7 @@ function runFastify (args, cb) {
     pluginOptions.prefix = opts.prefix
   }
 
-  fastify.register(file, pluginOptions)
+  fastify.register(file.default || file, pluginOptions)
 
   if (opts.address) {
     fastify.listen(opts.port, opts.address, wrap)

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -47,12 +47,47 @@ test('should start the server', t => {
   })
 })
 
+test('should start the server with a typescript compiled module', t => {
+  t.plan(6)
+
+  const argv = ['-p', getPort(), './examples/ts-plugin.js']
+  start.start(argv, function (err, fastify) {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: `http://localhost:${fastify.server.address().port}`
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.deepEqual(JSON.parse(body), { hello: 'world' })
+      fastify.close(() => {
+        t.pass('server closed')
+      })
+    })
+  })
+})
+
 test('should start fastify with custom options', t => {
   t.plan(1)
   // here the test should fail because of the wrong certificate
   // or because the server is booted without the custom options
   try {
     const argv = ['-p', getPort(), '-o', 'true', './examples/plugin-with-options.js']
+    start.start(argv).close()
+    t.fail('Custom options')
+  } catch (e) {
+    t.pass('Custom options')
+  }
+})
+
+test('should start fastify with custom options with a typescript compiled plugin', t => {
+  t.plan(1)
+  // here the test should fail because of the wrong certificate
+  // or because the server is booted without the custom options
+  try {
+    const argv = ['-p', getPort(), '-o', 'true', './examples/ts-plugin-with-options.js']
     start.start(argv).close()
     t.fail('Custom options')
   } catch (e) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

adding support for a typescript compiled module with exports.default syntax. I took the path of least resistance, although I'm open to an alternate implementation in the util.js file like so (or something else 😄 ):

```
function requireServerPluginFromPath (modulePath) {
  const resolvedModulePath = path.resolve(process.cwd(), modulePath)

  if (!fs.existsSync(resolvedModulePath)) {
    throw new Error(`${resolvedModulePath} doesn't exist within ${process.cwd()}`)
  }

  let serverPlugin = require(resolvedModulePath)

  if (isInvalidAsyncPlugin(serverPlugin)) {
    return new Error('Async/Await plugin function should contain 2 arguments.' +
      'Refer to documentation for more information.')
  }

  if (serverPlugin.default) {
    Object.assign(serverPlugin.default, serverPlugin)
    serverPlugin = serverPlugin.default
  }

  return serverPlugin
}
```