### PR TITLE
Add ability to specify the debug host

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ You can pass the following options via cli arguments, every options has the corr
 | Log level (default to fatal) | `-l` | `--log-level` | `FASTIFY_LOG_LEVEL` |
 | Start fastify app in debug mode with nodejs inspector | `-d` | `--debug` | `FASTIFY_DEBUG` |
 | Set the inspector port (default: 9320) | `-I` | `--debug-port` | `FASTIFY_DEBUG_PORT` |
+| Set the inspector host to listen on (default: loopback address or `0.0.0.0` inside Docker) | | `--debug-host` | `FASTIFY_DEBUG_HOST` |
 | Prints pretty logs | `-P` | `--pretty-logs` | `FASTIFY_PRETTY_LOGS` |
 | Watch process.cwd() directory for changes, recursively; when that happens, the process will auto reload. | `-w` | `--watch` | `FASTIFY_WATCH` |
 | Ignore changes to the specified files or directories when watch is enabled. (e.g. `--ignore-watch='node_modules .git logs/error.log'` )|  | `--ignore-watch` | `FASTIFY_IGNORE_WATCH` |

--- a/args.js
+++ b/args.js
@@ -6,7 +6,7 @@ module.exports = function parseArgs (args) {
   const parsedArgs = argv(args, {
     number: ['port', 'inspect-port', 'body-limit', 'plugin-timeout'],
     boolean: ['pretty-logs', 'options', 'watch', 'debug'],
-    string: ['log-level', 'address', 'socket', 'prefix', 'ignore-watch', 'logging-module'],
+    string: ['log-level', 'address', 'socket', 'prefix', 'ignore-watch', 'logging-module', 'debug-host'],
     envPrefix: 'FASTIFY_',
     alias: {
       port: ['p'],
@@ -45,6 +45,7 @@ module.exports = function parseArgs (args) {
     watch: parsedArgs.watch,
     debug: parsedArgs.debug,
     debugPort: parsedArgs.debugPort,
+    debugHost: parsedArgs.debugHost,
     ignoreWatch: parsedArgs.ignoreWatch,
     logLevel: parsedArgs.logLevel,
     address: parsedArgs.address,

--- a/start.js
+++ b/start.js
@@ -105,7 +105,7 @@ function runFastify (args, cb) {
     if (process.version.match(/v[0-6]\..*/g)) {
       stop('Fastify debug mode not compatible with Node.js version < 6')
     } else {
-      require('inspector').open(opts.debugPort, opts.debugHost || isDocker() ? '0.0.0.0' : '127.0.0.1')
+      require('inspector').open(opts.debugPort, opts.debugHost || isDocker() ? '0.0.0.0' : undefined)
     }
   }
 

--- a/start.js
+++ b/start.js
@@ -105,7 +105,7 @@ function runFastify (args, cb) {
     if (process.version.match(/v[0-6]\..*/g)) {
       stop('Fastify debug mode not compatible with Node.js version < 6')
     } else {
-      require('inspector').open(opts.debugPort)
+      require('inspector').open(opts.debugPort, opts.debugHost || isDocker() ? '0.0.0.0' : '127.0.0.1')
     }
   }
 

--- a/start.js
+++ b/start.js
@@ -105,7 +105,7 @@ function runFastify (args, cb) {
     if (process.version.match(/v[0-6]\..*/g)) {
       stop('Fastify debug mode not compatible with Node.js version < 6')
     } else {
-      require('inspector').open(opts.debugPort, opts.debugHost || isDocker() ? '0.0.0.0' : undefined)
+      require('inspector').open(opts.debugPort, opts.debugHost || isDocker() ? listenAddressDocker : undefined)
     }
   }
 

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -19,6 +19,7 @@ test('should parse args correctly', t => {
     '--body-limit', '5242880',
     '--debug', 'true',
     '--debug-port', 1111,
+    '--debug-host', '1.1.1.1',
     '--logging-module', './custom-logger.js',
     'app.js'
   ]
@@ -39,6 +40,7 @@ test('should parse args correctly', t => {
     bodyLimit: 5242880,
     debug: true,
     debugPort: 1111,
+    debugHost: '1.1.1.1',
     loggingModule: './custom-logger.js'
   })
 })
@@ -60,6 +62,7 @@ test('should parse args with = assignment correctly', t => {
     '--body-limit=5242880',
     '--debug=true',
     '--debug-port', 1111,
+    '--debug-host', '1.1.1.1',
     '--logging-module', './custom-logger.js',
     'app.js'
   ]
@@ -80,6 +83,7 @@ test('should parse args with = assignment correctly', t => {
     bodyLimit: 5242880,
     debug: true,
     debugPort: 1111,
+    debugHost: '1.1.1.1',
     loggingModule: './custom-logger.js'
   })
 })
@@ -100,6 +104,7 @@ test('should parse env vars correctly', t => {
   process.env.FASTIFY_PLUGIN_TIMEOUT = '500'
   process.env.FASTIFY_DEBUG = 'true'
   process.env.FASTIFY_DEBUG_PORT = '1111'
+  process.env.FASTIFY_DEBUG_HOST = '1.1.1.1'
   process.env.FASTIFY_LOGGING_MODULE = './custom-logger.js'
 
   t.teardown(function () {
@@ -136,6 +141,7 @@ test('should parse env vars correctly', t => {
     pluginTimeout: 500,
     debug: true,
     debugPort: 1111,
+    debugHost: '1.1.1.1',
     loggingModule: './custom-logger.js'
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

This PR allows specifying a debug host using the `--debug-host=x.x.x.x` argument. In addition, when the debug mode is started inside a docker container, the debug host will be automatically set to `0.0.0.0` unless specified otherwise. 