### PR TITLE
lock pino-colada

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "help-me": "^1.1.0",
     "is-docker": "^2.0.0",
     "make-promises-safe": "^5.0.0",
-    "pino-colada": "^2.0.0",
+    "pino-colada": "1.5.1",
     "pump": "^3.0.0",
     "resolve-from": "^5.0.0",
     "yargs-parser": "^18.1.1"

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -47,6 +47,28 @@ test('should start the server', t => {
   })
 })
 
+test('should start the server with pretty output', t => {
+  t.plan(6)
+
+  const argv = ['-p', getPort(), '-P', './examples/plugin.js']
+  start.start(argv, function (err, fastify) {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: `http://localhost:${fastify.server.address().port}`
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.deepEqual(JSON.parse(body), { hello: 'world' })
+      fastify.close(() => {
+        t.pass('server closed')
+      })
+    })
+  })
+})
+
 test('should start the server with a typescript compiled module', t => {
   t.plan(6)
 


### PR DESCRIPTION
We should lock the dep of pino-colada to fix the `-P` parameter
There was already the v2.0.0 on master but it drops the older node so we could not release it with fastify v2

Fixes #235 
Ref https://github.com/lrlna/pino-colada/issues/34
