### PR TITLE
feat: pass custom plugin options from cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ module.exports = async function (fastify, options) {
 
 For a list of available flags for `fastify start` see the help: `fastify help start`.
 
-If you want to use custom options, just export an options object with your route and run the cli command with the `--options` flag.
+If you want to use custom options for the server creation, just export an options object with your route and run the cli command with the `--options` flag.
 
 ```js
 // plugin.js
@@ -90,6 +90,23 @@ module.exports.options = {
     cert: 'cert'
   }
 }
+```
+
+If you want to use custom options for your plugin, just add them after the `--` terminator.
+
+```js
+// plugin.js
+module.exports = function (fastify, options, next) {
+  if (option.one) {
+    //...
+  }
+  //...
+  next()
+}
+```
+
+```bash
+$ fastify start plugin.js -- --one
 ```
 
 #### Options

--- a/args.js
+++ b/args.js
@@ -4,6 +4,9 @@ const argv = require('yargs-parser')
 
 module.exports = function parseArgs (args) {
   const parsedArgs = argv(args, {
+    configuration: {
+      'populate--': true
+    },
     number: ['port', 'inspect-port', 'body-limit', 'plugin-timeout'],
     boolean: ['pretty-logs', 'options', 'watch', 'debug'],
     string: ['log-level', 'address', 'socket', 'prefix', 'ignore-watch', 'logging-module', 'debug-host', 'lang'],
@@ -36,11 +39,16 @@ module.exports = function parseArgs (args) {
     }
   })
 
+  const additionalArgs = parsedArgs['--'] || []
+  const { _, ...pluginOptions } = argv(additionalArgs)
+
   return {
     _: parsedArgs._,
+    '--': additionalArgs,
     port: parsedArgs.port,
     bodyLimit: parsedArgs.bodyLimit,
     pluginTimeout: parsedArgs.pluginTimeout,
+    pluginOptions,
     prettyLogs: parsedArgs.prettyLogs,
     options: parsedArgs.options,
     watch: parsedArgs.watch,

--- a/examples/plugin-with-custom-options.js
+++ b/examples/plugin-with-custom-options.js
@@ -1,0 +1,6 @@
+'use strict'
+
+module.exports = function (fastify, options, next) {
+  fastify.get('/', (req, reply) => reply.send(options))
+  next()
+}

--- a/examples/ts-plugin-with-custom-options.js
+++ b/examples/ts-plugin-with-custom-options.js
@@ -1,0 +1,6 @@
+'use strict'
+
+exports.default = function (fastify, options, next) {
+  fastify.get('/', (req, reply) => reply.send(options))
+  next()
+}

--- a/help/start.txt
+++ b/help/start.txt
@@ -1,4 +1,6 @@
-Usage: fastify start [opts] <file>
+Usage: fastify start [opts] <file> [--] [<plugin-options>]
+
+OPTS
 
   -p, --port
   [env: FASTIFY_PORT or PORT]
@@ -45,3 +47,13 @@ Usage: fastify start [opts] <file>
 
   -h, --help
       Show this help message
+
+Examples:
+
+  start plugin.js on port 8080
+
+    fastify start -p 8080 plugin.js
+
+  start plugin.js passing custom options to it
+
+    fastify start plugin.js -- --custom-plugin-option-1 --custom-plugin-option-2

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "standard",
-    "unit": "cross-env TS_NODE_PROJECT=./templates/app-ts/tsconfig.json tap test/generate-typescript.test.js templates/app/test/*/*.test.js templates/app-ts/test/*/*.test.ts",
+    "unit": "cross-env TS_NODE_PROJECT=./templates/app-ts/tsconfig.json tap test/*.test.js templates/app/test/*/*.test.js templates/app-ts/test/*/*.test.ts",
     "test": "npm run lint && npm run unit"
   },
   "keywords": [

--- a/start.js
+++ b/start.js
@@ -111,12 +111,11 @@ function runFastify (args, cb) {
 
   const fastify = Fastify(opts.options ? Object.assign(options, file.options) : options)
 
-  const pluginOptions = {}
   if (opts.prefix) {
-    pluginOptions.prefix = opts.prefix
+    opts.pluginOptions.prefix = opts.prefix
   }
 
-  fastify.register(file.default || file, pluginOptions)
+  fastify.register(file.default || file, opts.pluginOptions)
 
   if (opts.address) {
     fastify.listen(opts.port, opts.address, wrap)

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -27,6 +27,7 @@ test('should parse args correctly', t => {
 
   t.strictDeepEqual(parsedArgs, {
     _: ['app.js'],
+    '--': [],
     prettyLogs: true,
     options: true,
     watch: true,
@@ -37,6 +38,7 @@ test('should parse args correctly', t => {
     logLevel: 'info',
     prefix: 'FASTIFY_',
     pluginTimeout: 500,
+    pluginOptions: {},
     bodyLimit: 5242880,
     debug: true,
     debugPort: 1111,
@@ -71,6 +73,7 @@ test('should parse args with = assignment correctly', t => {
 
   t.strictDeepEqual(parsedArgs, {
     _: ['app.js'],
+    '--': [],
     prettyLogs: true,
     options: true,
     watch: true,
@@ -81,6 +84,7 @@ test('should parse args with = assignment correctly', t => {
     logLevel: 'info',
     prefix: 'FASTIFY_',
     pluginTimeout: 500,
+    pluginOptions: {},
     bodyLimit: 5242880,
     debug: true,
     debugPort: 1111,
@@ -130,6 +134,7 @@ test('should parse env vars correctly', t => {
 
   t.strictDeepEqual(parsedArgs, {
     _: [],
+    '--': [],
     prettyLogs: true,
     options: true,
     watch: true,
@@ -141,6 +146,7 @@ test('should parse env vars correctly', t => {
     prefix: 'FASTIFY_',
     socket: 'fastify.io.socket:9999',
     pluginTimeout: 500,
+    pluginOptions: {},
     debug: true,
     debugPort: 1111,
     debugHost: '1.1.1.1',
@@ -168,4 +174,62 @@ test('should respect default values', t => {
   t.is(parsedArgs.debug, false)
   t.is(parsedArgs.debugPort, 9320)
   t.is(parsedArgs.loggingModule, undefined)
+})
+
+test('should parse custom plugin options', t => {
+  t.plan(1)
+
+  const argv = [
+    '--port', '7777',
+    '--address', 'fastify.io:9999',
+    '--socket', 'fastify.io.socket:9999',
+    '--log-level', 'info',
+    '--pretty-logs', 'true',
+    '--watch', 'true',
+    '--ignore-watch', 'ignoreme.js',
+    '--options', 'true',
+    '--prefix', 'FASTIFY_',
+    '--plugin-timeout', '500',
+    '--body-limit', '5242880',
+    '--debug', 'true',
+    '--debug-port', 1111,
+    '--debug-host', '1.1.1.1',
+    '--logging-module', './custom-logger.js',
+    'app.js',
+    '--',
+    '-abc',
+    '--hello', 'world'
+  ]
+  const parsedArgs = parseArgs(argv)
+
+  t.strictDeepEqual(parsedArgs, {
+    _: ['app.js'],
+    '--': [
+      '-abc',
+      '--hello',
+      'world'
+    ],
+    prettyLogs: true,
+    options: true,
+    watch: true,
+    ignoreWatch: 'ignoreme.js',
+    port: 7777,
+    address: 'fastify.io:9999',
+    socket: 'fastify.io.socket:9999',
+    logLevel: 'info',
+    prefix: 'FASTIFY_',
+    pluginTimeout: 500,
+    pluginOptions: {
+      a: true,
+      b: true,
+      c: true,
+      hello: 'world'
+    },
+    bodyLimit: 5242880,
+    debug: true,
+    debugPort: 1111,
+    debugHost: '1.1.1.1',
+    loggingModule: './custom-logger.js',
+    lang: 'js'
+  })
 })

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -82,6 +82,41 @@ test('should start fastify with custom options', t => {
   }
 })
 
+test('should start fastify with custom plugin options', t => {
+  t.plan(6)
+
+  const argv = [
+    '-p',
+    getPort(),
+    './examples/plugin-with-custom-options.js',
+    '--',
+    '-abc',
+    '--hello',
+    'world'
+  ]
+  start.start(argv, function (err, fastify) {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: `http://localhost:${fastify.server.address().port}`
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.deepEqual(JSON.parse(body), {
+        a: true,
+        b: true,
+        c: true,
+        hello: 'world'
+      })
+      fastify.close(() => {
+        t.pass('server closed')
+      })
+    })
+  })
+})
+
 test('should start fastify with custom options with a typescript compiled plugin', t => {
   t.plan(1)
   // here the test should fail because of the wrong certificate
@@ -93,6 +128,41 @@ test('should start fastify with custom options with a typescript compiled plugin
   } catch (e) {
     t.pass('Custom options')
   }
+})
+
+test('should start fastify with custom plugin options with a typescript compiled plugin', t => {
+  t.plan(6)
+
+  const argv = [
+    '-p',
+    getPort(),
+    './examples/ts-plugin-with-custom-options.js',
+    '--',
+    '-abc',
+    '--hello',
+    'world'
+  ]
+  start.start(argv, function (err, fastify) {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: `http://localhost:${fastify.server.address().port}`
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.deepEqual(JSON.parse(body), {
+        a: true,
+        b: true,
+        c: true,
+        hello: 'world'
+      })
+      fastify.close(() => {
+        t.pass('server closed')
+      })
+    })
+  })
 })
 
 test('should start the server at the given prefix', t => {


### PR DESCRIPTION
Allow passing custom options for the app plugin using additional arguments from the cli. All the args passed after `--` will be parsed and passed to the plugin as options.

Fixes #240 .

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
