### PR TITLE
update ignore-watch default values with .swp files

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ You can pass the following options via cli arguments, every options has the corr
 By default `fastify-cli` runs [`dotenv`](https://www.npmjs.com/package/dotenv), so it will load all the env variables stored in `.env` in your current working directory.
 
 The default value for `--plugin-timeout` is 10 seconds.
+By default `--ignore-watch` flag is set to ignore `node_modules build dist .git bower_components logs .swp' files.
 
 #### Fastify version discovery
 

--- a/args.js
+++ b/args.js
@@ -32,7 +32,7 @@ module.exports = function parseArgs (args) {
       watch: false,
       debug: false,
       debugPort: 9320,
-      'ignore-watch': 'node_modules build dist .git bower_components logs',
+      'ignore-watch': 'node_modules build dist .git bower_components logs .swp',
       options: false,
       'plugin-timeout': 10 * 1000, // everything should load in 10 seconds
       lang: 'js'

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -168,7 +168,7 @@ test('should respect default values', t => {
   t.is(parsedArgs.options, false)
   t.is(parsedArgs.prettyLogs, false)
   t.is(parsedArgs.watch, false)
-  t.is(parsedArgs.ignoreWatch, 'node_modules build dist .git bower_components logs')
+  t.is(parsedArgs.ignoreWatch, 'node_modules build dist .git bower_components logs .swp')
   t.is(parsedArgs.logLevel, 'fatal')
   t.is(parsedArgs.pluginTimeout, 10000)
   t.is(parsedArgs.debug, false)


### PR DESCRIPTION
Added .swp files to the list of default values to ignore-watch for


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
