### PR TITLE
feat: start can now watch ts files (#246)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,8 @@ test.sock
 # test artifacts
 test/workdir
 test/fixtures/*.js
+test/fixtures/*.ts
 .vscode/launch.json
+
+# ts compiled
+dist

--- a/args.js
+++ b/args.js
@@ -9,7 +9,7 @@ module.exports = function parseArgs (args) {
     },
     number: ['port', 'inspect-port', 'body-limit', 'plugin-timeout'],
     boolean: ['pretty-logs', 'options', 'watch', 'debug'],
-    string: ['log-level', 'address', 'socket', 'prefix', 'ignore-watch', 'logging-module', 'debug-host', 'lang'],
+    string: ['log-level', 'address', 'socket', 'prefix', 'ignore-watch', 'logging-module', 'debug-host', 'lang', 'tsconfig'],
     envPrefix: 'FASTIFY_',
     alias: {
       port: ['p'],
@@ -35,7 +35,8 @@ module.exports = function parseArgs (args) {
       'ignore-watch': 'node_modules build dist .git bower_components logs .swp',
       options: false,
       'plugin-timeout': 10 * 1000, // everything should load in 10 seconds
-      lang: 'js'
+      lang: 'js',
+      tsconfig: 'tsconfig.json'
     }
   })
 
@@ -61,6 +62,7 @@ module.exports = function parseArgs (args) {
     socket: parsedArgs.socket,
     prefix: parsedArgs.prefix,
     loggingModule: parsedArgs.loggingModule,
-    lang: parsedArgs.lang
+    lang: parsedArgs.lang,
+    tsconfig: parsedArgs.tsconfig
   }
 }

--- a/examples/plugin.ts
+++ b/examples/plugin.ts
@@ -1,0 +1,10 @@
+import { FastifyPluginAsync } from 'fastify'
+
+const root: FastifyPluginAsync = async (fastify, opts): Promise<void> => {
+  fastify.decorate('test', true)
+  fastify.get('/', async function (request, reply) {
+    return { hello: 'world' }
+  })
+}
+
+export default root;

--- a/generate.js
+++ b/generate.js
@@ -47,7 +47,7 @@ const typescriptTemplate = {
     test: 'npm run build:ts && tsc -p test/tsconfig.test.json && tap test/**/*.test.ts',
     start: 'npm run build:ts && fastify start -l info dist/app.js',
     'build:ts': 'tsc',
-    dev: 'tsc && concurrently -k -p "[{name}]" -n "TypeScript,App" -c "yellow.bold,cyan.bold"  "tsc -w" "fastify start -w -l info -P dist/app.js"'
+    dev: 'fastify start -w -l info -P src/app.ts'
   },
   dependencies: {
     fastify: cliPkg.dependencies.fastify,
@@ -58,7 +58,6 @@ const typescriptTemplate = {
   devDependencies: {
     '@types/node': cliPkg.devDependencies['@types/node'],
     '@types/tap': cliPkg.devDependencies['@types/tap'],
-    concurrently: cliPkg.devDependencies.concurrently,
     'fastify-tsconfig': cliPkg.devDependencies['fastify-tsconfig'],
     tap: cliPkg.devDependencies.tap,
     typescript: cliPkg.devDependencies.typescript

--- a/lib/watch/tsc-watcher.js
+++ b/lib/watch/tsc-watcher.js
@@ -17,7 +17,7 @@ let child
 
 const emitter = new EventEmitter()
 
-async function watchMain (args, opts) {
+function watchMain (args, opts) {
   const configPath = ts.findConfigFile(
     './',
     ts.sys.fileExists,
@@ -50,7 +50,7 @@ async function watchMain (args, opts) {
   const appFile = resolve(configFile.compilerOptions.outDir, basename(opts._[0]).replace(/.ts$/, '.js'))
   args.splice(args.length - 1, 1, appFile)
 
-  host.afterProgramCreate = async program => {
+  host.afterProgramCreate = program => {
     if (child) {
       child.send(GRACEFUL_SHUT)
     }

--- a/lib/watch/tsc-watcher.js
+++ b/lib/watch/tsc-watcher.js
@@ -1,0 +1,104 @@
+'use strict'
+
+const ts = require('typescript')
+const { EventEmitter } = require('events')
+const formatHost = {
+  getCanonicalFileName: path => path,
+  getCurrentDirectory: ts.sys.getCurrentDirectory,
+  getNewLine: () => ts.sys.newLine
+}
+const { resolve, join, basename } = require('path')
+const cp = require('child_process')
+const forkPath = join(__dirname, './fork.js')
+const {
+  GRACEFUL_SHUT
+} = require('./constants')
+let child
+
+const emitter = new EventEmitter()
+
+async function watchMain (args, opts) {
+  const configPath = ts.findConfigFile(
+    './',
+    ts.sys.fileExists,
+    opts.tsconfig || 'tsconfig.json'
+  )
+
+  if (!configPath) {
+    throw new Error('Could not find a valid \'tsconfig.json\'.')
+  }
+
+  const createProgram = ts.createSemanticDiagnosticsBuilderProgram
+
+  const host = ts.createWatchCompilerHost(
+    configPath,
+    {},
+    ts.sys,
+    createProgram,
+    reportDiagnostic,
+    reportWatchStatusChanged
+  )
+
+  const origCreateProgram = host.createProgram
+  host.createProgram = (rootNames, options, host, oldProgram) => {
+    return origCreateProgram(rootNames, options, host, oldProgram)
+  }
+  const origPostProgramCreate = host.afterProgramCreate
+
+  const configFile = require(resolve(process.cwd(), configPath))
+
+  const appFile = resolve(configFile.compilerOptions.outDir, basename(opts._[0]).replace(/.ts$/, '.js'))
+  args.splice(args.length - 1, 1, appFile)
+
+  host.afterProgramCreate = async program => {
+    if (child) {
+      child.send(GRACEFUL_SHUT)
+    }
+    origPostProgramCreate(program)
+
+    child = cp.fork(forkPath, args, {
+      cwd: process.cwd(),
+      encoding: 'utf8'
+    })
+    let readyEmitted = false
+
+    child.on('message', (event) => {
+      const { type, err } = event
+      if (err) {
+        child.emit('error', err)
+        return null
+      }
+
+      if (type === 'ready') {
+        if (readyEmitted) {
+          return
+        }
+
+        readyEmitted = true
+      }
+
+      emitter.emit(type, err)
+    })
+  }
+
+  ts.createWatchProgram(host)
+
+  return emitter
+}
+
+emitter.on('close', () => {
+  if (child) {
+    child.kill()
+    process.exit(0)
+  }
+})
+
+function reportDiagnostic (diagnostic) {
+  console.log('Error', diagnostic.code, ':', ts.flattenDiagnosticMessageText(diagnostic.messageText, formatHost.getNewLine()))
+}
+
+function reportWatchStatusChanged (diagnostic) {
+  console.info(ts.formatDiagnostic(diagnostic, formatHost))
+}
+
+module.exports = watchMain

--- a/lib/watch/tsc-watcher.js
+++ b/lib/watch/tsc-watcher.js
@@ -7,7 +7,7 @@ const formatHost = {
   getCurrentDirectory: ts.sys.getCurrentDirectory,
   getNewLine: () => ts.sys.newLine
 }
-const { resolve, join, basename } = require('path')
+const { resolve, join, basename, dirname } = require('path')
 const cp = require('child_process')
 const forkPath = join(__dirname, './fork.js')
 const {
@@ -47,7 +47,7 @@ function watchMain (args, opts) {
 
   const configFile = require(resolve(process.cwd(), configPath))
 
-  const appFile = resolve(configFile.compilerOptions.outDir, basename(opts._[0]).replace(/.ts$/, '.js'))
+  const appFile = join(resolve(dirname(configPath), configFile.compilerOptions.outDir), basename(opts._[0]).replace(/.ts$/, '.js'))
   args.splice(args.length - 1, 1, appFile)
 
   host.afterProgramCreate = program => {

--- a/start.js
+++ b/start.js
@@ -12,7 +12,6 @@ const pump = require('pump')
 const isDocker = require('is-docker')
 const listenAddressDocker = '0.0.0.0'
 const watch = require('./lib/watch')
-const tsWatch = require('./lib/watch/tsc-watcher')
 const parseArgs = require('./args')
 const { exit, requireFastifyForModule, requireServerPluginFromPath, showHelpForCommand } = require('./util')
 
@@ -45,7 +44,7 @@ async function start (args) {
   require('make-promises-safe')
 
   if (path.extname(opts._[0]) === '.ts') {
-    return tsWatch(args, opts)
+    return require('./lib/watch/tsc-watcher')(args, opts)
   }
 
   loadModules(opts)

--- a/start.js
+++ b/start.js
@@ -12,6 +12,7 @@ const pump = require('pump')
 const isDocker = require('is-docker')
 const listenAddressDocker = '0.0.0.0'
 const watch = require('./lib/watch')
+const tsWatch = require('./lib/watch/tsc-watcher')
 const parseArgs = require('./args')
 const { exit, requireFastifyForModule, requireServerPluginFromPath, showHelpForCommand } = require('./util')
 
@@ -19,7 +20,8 @@ let Fastify = null
 
 function loadModules (opts) {
   try {
-    const { module: fastifyModule } = requireFastifyForModule(opts._[0])
+    const app = opts._[0]
+    const { module: fastifyModule } = requireFastifyForModule(app)
 
     Fastify = fastifyModule
   } catch (e) {
@@ -29,6 +31,7 @@ function loadModules (opts) {
 
 async function start (args) {
   const opts = parseArgs(args)
+
   if (opts.help) {
     return showHelpForCommand('start')
   }
@@ -40,6 +43,10 @@ async function start (args) {
 
   // we start crashing on unhandledRejection
   require('make-promises-safe')
+
+  if (path.extname(opts._[0]) === '.ts') {
+    return tsWatch(args, opts)
+  }
 
   loadModules(opts)
 

--- a/templates/app-ts/src/routes/example/index.ts
+++ b/templates/app-ts/src/routes/example/index.ts
@@ -1,6 +1,6 @@
 import { FastifyPluginAsync } from "fastify"
 
-const example: FastifyPluginAsync =async (fastify, opts): Promise<void> => {
+const example: FastifyPluginAsync = async (fastify, opts): Promise<void> => {
   fastify.get('/', async function (request, reply) {
     return 'this is an example'
   })

--- a/templates/app-ts/tsconfig.json
+++ b/templates/app-ts/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "fastify-tsconfig",
     "compilerOptions": {
+        "esModuleInterop": true,
         "outDir": "dist"
     },
     "include": ["src/**/*.ts"]

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -44,7 +44,8 @@ test('should parse args correctly', t => {
     debugPort: 1111,
     debugHost: '1.1.1.1',
     loggingModule: './custom-logger.js',
-    lang: 'js'
+    lang: 'js',
+    tsconfig: 'tsconfig.json'
   })
 })
 
@@ -90,7 +91,8 @@ test('should parse args with = assignment correctly', t => {
     debugPort: 1111,
     debugHost: '1.1.1.1',
     loggingModule: './custom-logger.js',
-    lang: 'js'
+    lang: 'js',
+    tsconfig: 'tsconfig.json'
   })
 })
 
@@ -151,7 +153,8 @@ test('should parse env vars correctly', t => {
     debugPort: 1111,
     debugHost: '1.1.1.1',
     loggingModule: './custom-logger.js',
-    lang: 'js'
+    lang: 'js',
+    tsconfig: 'tsconfig.json'
   })
 })
 
@@ -230,6 +233,7 @@ test('should parse custom plugin options', t => {
     debugPort: 1111,
     debugHost: '1.1.1.1',
     loggingModule: './custom-logger.js',
-    lang: 'js'
+    lang: 'js',
+    tsconfig: 'tsconfig.json'
   })
 })

--- a/test/generate-typescript.test.js
+++ b/test/generate-typescript.test.js
@@ -104,7 +104,7 @@ function define (t) {
   })
 
   test('should finish succesfully with typescript template', async (t) => {
-    t.plan(21 + Object.keys(expected).length)
+    t.plan(20 + Object.keys(expected).length)
     try {
       await generate(workdir, typescriptTemplate)
       await verifyPkg(t)
@@ -132,13 +132,12 @@ function define (t) {
         t.equal(pkg.scripts.test, 'npm run build:ts && tsc -p test/tsconfig.test.json && tap test/**/*.test.ts')
         t.equal(pkg.scripts.start, 'npm run build:ts && fastify start -l info dist/app.js')
         t.equal(pkg.scripts['build:ts'], 'tsc')
-        t.equal(pkg.scripts.dev, 'tsc && concurrently -k -p "[{name}]" -n "TypeScript,App" -c "yellow.bold,cyan.bold"  "tsc -w" "fastify start -w -l info -P dist/app.js"')
+        t.equal(pkg.scripts.dev, 'fastify start -w -l info -P src/app.ts')
         t.equal(pkg.dependencies['fastify-cli'], '^' + cliPkg.version)
         t.equal(pkg.dependencies.fastify, cliPkg.dependencies.fastify)
         t.equal(pkg.dependencies['fastify-plugin'], cliPkg.devDependencies['fastify-plugin'] || cliPkg.dependencies['fastify-plugin'])
         t.equal(pkg.dependencies['fastify-autoload'], cliPkg.devDependencies['fastify-autoload'])
         t.equal(pkg.devDependencies['@types/node'], cliPkg.devDependencies['@types/node'])
-        t.equal(pkg.devDependencies.concurrently, cliPkg.devDependencies.concurrently)
         t.equal(pkg.devDependencies.tap, cliPkg.devDependencies.tap)
         t.equal(pkg.devDependencies.typescript, cliPkg.devDependencies.typescript)
 

--- a/test/start-typescript.test.js
+++ b/test/start-typescript.test.js
@@ -5,23 +5,11 @@ const { once } = require('events')
 const fs = require('fs')
 const crypto = require('crypto')
 const baseFilename = `${__dirname}/fixtures/test_${crypto.randomBytes(16).toString('hex')}`
-
 const t = require('tap')
 const test = t.test
-const sgetOriginal = require('simple-get').concat
-const sget = (opts, cb) => {
-  return new Promise((resolve, reject) => {
-    sgetOriginal(opts, (err, response, body) => {
-      if (err) return reject(err)
-      return resolve({ response, body })
-    })
-  })
-}
+const { sgetOriginal } = require('./util')
+const sget = util.promisify(sgetOriginal)
 const start = require('../start')
-
-// FIXME
-// paths are relative to the root of the project
-// this can be run only from there
 
 test('should start the server with watch options and refresh app instance on directory change', async (t) => {
   t.plan(5)

--- a/test/start-typescript.test.js
+++ b/test/start-typescript.test.js
@@ -4,7 +4,9 @@ const util = require('util')
 const { once } = require('events')
 const fs = require('fs')
 const crypto = require('crypto')
+const { resolve, join } = require('path')
 const baseFilename = `${__dirname}/fixtures/test_${crypto.randomBytes(16).toString('hex')}`
+const root = join(__dirname, '..')
 const t = require('tap')
 const test = t.test
 const { sgetOriginal } = require('./util')
@@ -18,11 +20,12 @@ test('should start the server with watch options and refresh app instance on dir
   const copyFile = util.promisify(fs.copyFile)
   const readFile = util.promisify(fs.readFile)
   const tmpts = baseFilename + '.ts'
+  const example = resolve(__dirname, join(root, 'examples', 'plugin.ts'))
 
-  await copyFile('examples/plugin.ts', tmpts)
+  await copyFile(example, tmpts)
   t.pass('plugin copied to fixture')
 
-  const argv = ['-p', '5001', '-w', '--tsconfig', 'tsconfig.tswatch.json', tmpts]
+  const argv = ['-p', '5001', '-w', '--tsconfig', join(root, 'tsconfig.tswatch.json'), tmpts]
   const fastifyEmitter = await start.start(argv)
 
   await once(fastifyEmitter, 'ready')

--- a/test/start-typescript.test.js
+++ b/test/start-typescript.test.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const util = require('util')
+const { once } = require('events')
+const fs = require('fs')
+const crypto = require('crypto')
+const baseFilename = `${__dirname}/fixtures/test_${crypto.randomBytes(16).toString('hex')}`
+
+const t = require('tap')
+const test = t.test
+const sgetOriginal = require('simple-get').concat
+const sget = (opts, cb) => {
+  return new Promise((resolve, reject) => {
+    sgetOriginal(opts, (err, response, body) => {
+      if (err) return reject(err)
+      return resolve({ response, body })
+    })
+  })
+}
+const start = require('../start')
+
+// FIXME
+// paths are relative to the root of the project
+// this can be run only from there
+
+test('should start the server with watch options and refresh app instance on directory change', async (t) => {
+  t.plan(5)
+
+  const writeFile = util.promisify(fs.writeFile)
+  const copyFile = util.promisify(fs.copyFile)
+  const readFile = util.promisify(fs.readFile)
+  const tmpts = baseFilename + '.ts'
+
+  await copyFile('examples/plugin.ts', tmpts)
+  t.pass('plugin copied to fixture')
+
+  const argv = ['-p', '5001', '-w', '--tsconfig', 'tsconfig.tswatch.json', tmpts]
+  const fastifyEmitter = await start.start(argv)
+
+  await once(fastifyEmitter, 'ready')
+  t.pass('should receive ready event')
+
+  t.tearDown(() => {
+    if (fs.existsSync(tmpts)) {
+      fs.unlinkSync(tmpts)
+    }
+    fastifyEmitter.emit('close')
+  })
+
+  const data = await readFile(tmpts)
+
+  await writeFile(tmpts, data.toString().replace(/(world)/ig, 'fastify'))
+  t.pass('change tmpts')
+
+  await once(fastifyEmitter, 'ready')
+  t.pass('should receive ready after restart')
+
+  const { body } = await sget({
+    method: 'GET',
+    url: 'http://localhost:5001'
+  })
+  t.deepEqual(JSON.parse(body), { hello: 'fastify' })
+})

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -6,6 +6,7 @@ const fs = require('fs')
 const path = require('path')
 const crypto = require('crypto')
 const baseFilename = `${__dirname}/fixtures/test_${crypto.randomBytes(16).toString('hex')}`
+const root = path.join(__dirname, '..')
 const { fork } = require('child_process')
 
 const t = require('tap')
@@ -24,14 +25,10 @@ function getPort () {
   return '' + _port++
 }
 
-// FIXME
-// paths are relative to the root of the project
-// this can be run only from there
-
 test('should start the server', async t => {
   t.plan(4)
 
-  const argv = ['-p', getPort(), './examples/plugin.js']
+  const argv = ['-p', getPort(), path.join(root, 'examples/plugin.js')]
   const fastify = await start.start(argv)
 
   const { response, body } = await sget({
@@ -49,7 +46,7 @@ test('should start the server', async t => {
 test('should start the server with a typescript compiled module', async t => {
   t.plan(4)
 
-  const argv = ['-p', getPort(), './examples/ts-plugin.js']
+  const argv = ['-p', getPort(), path.join(root, 'examples/ts-plugin.js')]
   const fastify = await start.start(argv)
 
   const { response, body } = await sget({
@@ -67,7 +64,7 @@ test('should start the server with a typescript compiled module', async t => {
 test('should start the server with pretty output', async t => {
   t.plan(4)
 
-  const argv = ['-p', getPort(), '-P', './examples/plugin.js']
+  const argv = ['-p', getPort(), '-P', path.join(root, 'examples/plugin.js')]
   const fastify = await start.start(argv)
 
   const { response, body } = await sget({
@@ -87,7 +84,7 @@ test('should start fastify with custom options', async t => {
   // here the test should fail because of the wrong certificate
   // or because the server is booted without the custom options
   try {
-    const argv = ['-p', getPort(), '-o', 'true', './examples/plugin-with-options.js']
+    const argv = ['-p', getPort(), '-o', 'true', path.join(root, 'examples/plugin-with-options.js')]
     const fastify = await start.start(argv)
     await fastify.close()
     t.pass('server closed')
@@ -102,7 +99,7 @@ test('should start fastify with custom plugin options', async t => {
   const argv = [
     '-p',
     getPort(),
-    './examples/plugin-with-custom-options.js',
+    path.join(root, 'examples/plugin-with-custom-options.js'),
     '--',
     '-abc',
     '--hello',
@@ -133,7 +130,7 @@ test('should start fastify with custom options with a typescript compiled plugin
   // here the test should fail because of the wrong certificate
   // or because the server is booted without the custom options
   try {
-    const argv = ['-p', getPort(), '-o', 'true', './examples/ts-plugin-with-options.js']
+    const argv = ['-p', getPort(), '-o', 'true', path.join(root, 'examples/ts-plugin-with-options.js')]
     await start.start(argv)
     t.fail('Custom options')
   } catch (e) {
@@ -147,7 +144,7 @@ test('should start fastify with custom plugin options with a typescript compiled
   const argv = [
     '-p',
     getPort(),
-    './examples/ts-plugin-with-custom-options.js',
+    path.join(root, 'examples/ts-plugin-with-custom-options.js'),
     '--',
     '-abc',
     '--hello',
@@ -176,7 +173,7 @@ test('should start fastify with custom plugin options with a typescript compiled
 test('should start the server at the given prefix', async t => {
   t.plan(4)
 
-  const argv = ['-p', getPort(), '-r', '/api/hello', './examples/plugin.js']
+  const argv = ['-p', getPort(), '-r', '/api/hello', path.join(root, 'examples/plugin.js')]
   const fastify = await start.start(argv)
 
   const { response, body } = await sget({
@@ -201,7 +198,7 @@ test('should start fastify at given socket path', { skip: process.platform === '
       fs.unlinkSync(sockFile)
     } catch (e) { }
   })
-  const argv = ['-s', sockFile, '-o', 'true', './examples/plugin.js']
+  const argv = ['-s', sockFile, '-o', 'true', path.join(root, 'examples/plugin.js')]
 
   try {
     fs.unlinkSync(sockFile)
@@ -230,16 +227,16 @@ test('should error with a good timeout value', async t => {
   const start = proxyquire('../start', {
     assert: {
       ifError (err) {
-        t.equal(err.message, `ERR_AVVIO_PLUGIN_TIMEOUT: plugin did not start in time: ${path.join(__dirname, 'data', 'timeout-plugin.js')}`)
+        t.equal(err.message, `ERR_AVVIO_PLUGIN_TIMEOUT: plugin did not start in time: ${path.join(root, 'test', 'data', 'timeout-plugin.js')}`)
       }
     }
   })
 
   try {
-    const argv = ['-p', '3040', '-T', '100', './test/data/timeout-plugin.js']
+    const argv = ['-p', '3040', '-T', '100', path.join(root, 'test', 'data/timeout-plugin.js')]
     await start.start(argv)
   } catch (err) {
-    t.equal(err.message, `ERR_AVVIO_PLUGIN_TIMEOUT: plugin did not start in time: ${path.join(__dirname, 'data', 'timeout-plugin.js')}`)
+    t.equal(err.message, `ERR_AVVIO_PLUGIN_TIMEOUT: plugin did not start in time: ${path.join(root, 'test', 'data', 'timeout-plugin.js')}`)
   }
 })
 
@@ -252,7 +249,7 @@ test('should warn on file not found', t => {
     t.ok(/.*not-found.js doesn't exist within/.test(message), message)
   }
 
-  const argv = ['-p', getPort(), './data/not-found.js']
+  const argv = ['-p', getPort(), path.join(root, 'test', 'data/not-found.js')]
   start.start(argv)
 })
 
@@ -265,7 +262,7 @@ test('should throw on package not found', t => {
     t.ok(/Cannot find module 'unknown-package'/.test(err.message), err.message)
   }
 
-  const argv = ['-p', getPort(), './test/data/package-not-found.js']
+  const argv = ['-p', getPort(), path.join(root, 'test', 'data/package-not-found.js')]
   start.start(argv)
 })
 
@@ -278,7 +275,7 @@ test('should throw on parsing error', t => {
     t.equal(err.constructor, SyntaxError)
   }
 
-  const argv = ['-p', getPort(), './test/data/parsing-error.js']
+  const argv = ['-p', getPort(), path.join(root, 'test', 'data/parsing-error.js')]
   start.start(argv)
 })
 
@@ -290,7 +287,7 @@ test('should start the server with an async/await plugin', async t => {
 
   t.plan(4)
 
-  const argv = ['-p', getPort(), './examples/async-await-plugin.js']
+  const argv = ['-p', getPort(), path.join(root, 'examples/async-await-plugin.js')]
   const fastify = await start.start(argv)
 
   const { response, body } = await sget({
@@ -332,7 +329,7 @@ test('should throw the right error on require file', t => {
     t.ok(/undefinedVariable is not defined/.test(err.message), err.message)
   }
 
-  const argv = ['-p', getPort(), './test/data/undefinedVariable.js']
+  const argv = ['-p', getPort(), path.join(root, 'test', 'data/undefinedVariable.js')]
   start.start(argv)
 })
 
@@ -343,7 +340,7 @@ test('should respond 413 - Payload too large', async t => {
   const bodySmaller = '{1: 1}'
 
   const bodyLimitValue = '' + (bodyTooLarge.length + 2 - 1)
-  const argv = ['-p', getPort(), '--body-limit', bodyLimitValue, './examples/plugin.js']
+  const argv = ['-p', getPort(), '--body-limit', bodyLimitValue, path.join(root, 'examples/plugin.js')]
   const fastify = await start.start(argv)
 
   const { response: responseFail } = await sget({
@@ -371,7 +368,7 @@ test('should start the server (using env var)', async t => {
   t.plan(4)
 
   process.env.FASTIFY_PORT = getPort()
-  const argv = ['./examples/plugin.js']
+  const argv = [path.join(root, 'examples/plugin.js')]
   const fastify = await start.start(argv)
 
   const { response, body } = await sget({
@@ -392,7 +389,7 @@ test('should start the server (using PORT-env var)', async t => {
   t.plan(4)
 
   process.env.PORT = getPort()
-  const argv = ['./examples/plugin.js']
+  const argv = [path.join(root, 'examples/plugin.js')]
   const fastify = await start.start(argv)
 
   const { response, body } = await sget({
@@ -414,7 +411,7 @@ test('should start the server (using FASTIFY_PORT-env preceding PORT-env var)', 
 
   process.env.FASTIFY_PORT = getPort()
   process.env.PORT = getPort()
-  const argv = ['./examples/plugin.js']
+  const argv = [path.join(root, 'examples/plugin.js')]
   const fastify = await start.start(argv)
 
   const { response, body } = await sget({
@@ -438,7 +435,7 @@ test('should start the server (using -p preceding FASTIFY_PORT-env var)', async 
 
   const port = getPort()
   process.env.FASTIFY_PORT = getPort()
-  const argv = ['-p', port, './examples/plugin.js']
+  const argv = ['-p', port, path.join(root, 'examples/plugin.js')]
   const fastify = await start.start(argv)
 
   const { response, body } = await sget({
@@ -461,7 +458,7 @@ test('should start the server at the given prefix (using env var)', async t => {
 
   process.env.FASTIFY_PORT = getPort()
   process.env.FASTIFY_PREFIX = '/api/hello'
-  const argv = ['./examples/plugin.js']
+  const argv = [path.join(root, 'examples/plugin.js')]
   const fastify = await start.start(argv)
 
   const { response, body } = await sget({
@@ -490,7 +487,7 @@ test('should start the server at the given prefix (using env var read from doten
       }
     }
   })
-  const argv = ['./examples/plugin.js']
+  const argv = [path.join(root, 'examples/plugin.js')]
   const fastify = await start.start(argv)
   t.strictEqual(fastify.server.address().port, 8080)
   delete process.env.FASTIFY_PORT
@@ -508,7 +505,7 @@ test('should start the server listening on 0.0.0.0 when runing in docker', async
     'is-docker': isDocker
   })
 
-  const argv = ['-p', getPort(), './examples/plugin.js']
+  const argv = ['-p', getPort(), path.join(root, 'examples/plugin.js')]
   const fastify = await start.start(argv)
 
   t.strictEqual(fastify.server.address().address, '0.0.0.0')
@@ -523,7 +520,7 @@ test('should start the server with watch options that the child process restart 
   const tmpjs = path.resolve(baseFilename + '.js')
 
   await writeFile(tmpjs, 'hello world')
-  const argv = ['-p', '4042', '-w', './examples/plugin.js']
+  const argv = ['-p', '4042', '-w', path.join(root, 'examples/plugin.js')]
   const fastifyEmitter = await start.start(argv)
 
   t.tearDown(() => {
@@ -550,7 +547,7 @@ test('should start the server with watch options that the child process restart 
 test('crash on unhandled rejection', t => {
   t.plan(1)
 
-  const argv = ['-p', getPort(), './test/data/rejection.js']
+  const argv = ['-p', getPort(), path.join(root, 'test', 'data/rejection.js')]
   const child = fork(path.join(__dirname, '..', 'start.js'), argv, { silent: true })
   child.on('close', function (code) {
     t.strictEqual(code, 1)
@@ -568,7 +565,7 @@ test('should start the server with inspect options and the defalut port is 9320'
       }
     }
   })
-  const argv = ['--d', './examples/plugin.js']
+  const argv = ['--d', path.join(root, 'examples/plugin.js')]
   const fastify = await start.start(argv)
 
   await fastify.close()
@@ -587,7 +584,7 @@ test('should start the server with inspect options and use the exactly port', as
       }
     }
   })
-  const argv = ['--d', '--debug-port', port, './examples/plugin.js']
+  const argv = ['--d', '--debug-port', port, path.join(root, 'examples/plugin.js')]
   const fastify = await start.start(argv)
 
   await fastify.close()
@@ -602,7 +599,7 @@ test('boolean env are not overridden if no arguments are passed', async t => {
   // here the test should fail because of the wrong certificate
   // or because the server is booted without the custom options
   try {
-    const argv = ['./examples/plugin-with-options.js']
+    const argv = [path.join(root, 'examples/plugin-with-options.js')]
     await start.start(argv)
     t.fail('Custom options')
   } catch (e) {
@@ -613,7 +610,7 @@ test('boolean env are not overridden if no arguments are passed', async t => {
 test('should support custom logger configuration', async t => {
   t.plan(2)
 
-  const argv = ['-L', './test/data/custom-logger.js', './examples/plugin.js']
+  const argv = ['-L', path.join(root, 'test', 'data/custom-logger.js'), path.join(root, 'examples/plugin.js')]
   const fastify = await start.start(argv)
   t.ok(fastify.log.test)
 
@@ -630,7 +627,7 @@ test('should throw on logger configuration module not found', async t => {
     t.ok(/Cannot find module/.test(err.message), err.message)
   }
 
-  const argv = ['-L', './test/data/missing.js', './examples/plugin.js']
+  const argv = ['-L', path.join(root, 'test', 'data/missing.js'), path.join(root, 'examples/plugin.js')]
   const fastify = await start.start(argv)
 
   await fastify.close()

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -10,15 +10,8 @@ const { fork } = require('child_process')
 
 const t = require('tap')
 const test = t.test
-const sgetOriginal = require('simple-get').concat
-const sget = (opts, cb) => {
-  return new Promise((resolve, reject) => {
-    sgetOriginal(opts, (err, response, body) => {
-      if (err) return reject(err)
-      return resolve({ response, body })
-    })
-  })
-}
+const { sgetOriginal } = require('./util')
+const sget = util.promisify(sgetOriginal)
 const sinon = require('sinon')
 const proxyquire = require('proxyquire').noPreserveCache()
 const start = require('../start')

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,12 @@
+const util = require('util')
+const sgetOriginal = require('simple-get').concat
+sgetOriginal[util.promisify.custom] = (opts, cb) => {
+  return new Promise((resolve, reject) => {
+    sgetOriginal(opts, (err, response, body) => {
+      if (err) return reject(err)
+      return resolve({ response, body })
+    })
+  })
+}
+
+module.exports = { sgetOriginal }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "fastify-tsconfig",
     "compilerOptions": {
       "esModuleInterop": true,
-      "noEmit": true
+      "outDir": "dist"
     },
     "include": [
         "routes/**/*.ts",

--- a/tsconfig.tswatch.json
+++ b/tsconfig.tswatch.json
@@ -1,0 +1,10 @@
+{
+  "extends": "fastify-tsconfig",
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "outDir": "dist"
+  },
+  "include": [
+    "test/fixtures/**/*.ts"
+  ]
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


The idea is that we should make the user run `fastify start...` on .ts files and watch for changes on those files.
At the moment the `npm run dev` script in ts project template uses `concurrently` so we basically have 2 watchers running together: one for ts files and one for the compiled `dist` files.
This is not ideal.
This approach uses only the tsc API to watch for .ts files changes. Every time it detects a change it kills fastify process, re-compiles changed files, restarts fastify.

Note: for the moment I assumed that if the target file is a .ts file we always want to watch it even without `-w` option.
Note: [docs](https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-

Any suggestion is well accepted.