### PR TITLE
Update doc links in template READMEs to point to fastify.io

### DIFF
--- a/templates/app-ts/src/plugins/README.md
+++ b/templates/app-ts/src/plugins/README.md
@@ -11,6 +11,6 @@ that will then be used in the rest of your application.
 
 Check out:
 
-* [The hitchhiker's guide to plugins](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md)
+* [The hitchhiker's guide to plugins](https://www.fastify.io/docs/latest/Plugins-Guide/)
 * [Fastify decorators](https://www.fastify.io/docs/latest/Decorators/).
 * [Fastify lifecycle](https://www.fastify.io/docs/latest/Lifecycle/).

--- a/templates/app/plugins/README.md
+++ b/templates/app/plugins/README.md
@@ -11,6 +11,6 @@ that will then be used in the rest of your application.
 
 Check out:
 
-* [The hitchhiker's guide to plugins](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md)
+* [The hitchhiker's guide to plugins](https://www.fastify.io/docs/latest/Plugins-Guide/)
 * [Fastify decorators](https://www.fastify.io/docs/latest/Decorators/).
 * [Fastify lifecycle](https://www.fastify.io/docs/latest/Lifecycle/).

--- a/templates/app/routes/README.md
+++ b/templates/app/routes/README.md
@@ -23,4 +23,5 @@ If you need to share functionality between services, place that
 functionality into the `plugins` folder, and share it via
 [decorators](https://www.fastify.io/docs/latest/Decorators/).
 
-If you're a bit confused about using `async/await` to write services, you would better take a look at [Promise resolution](https://github.com/fastify/fastify/blob/master/docs/Routes.md#promise-resolution) for more details.
+If you're a bit confused about using `async/await` to write services, you would
+better take a look at [Promise resolution](https://www.fastify.io/docs/latest/Routes/#promise-resolution) for more details.


### PR DESCRIPTION
Found a couple dead links and figured it was better to match the rest of the READMEs and link to fastify.io documentation instead of github.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
