### PR TITLE
Ts watch fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,8 +51,9 @@ test.sock
 
 # test artifacts
 test/workdir
-test/fixtures/*.js
-test/fixtures/*.ts
+test/fixtures/**/*.js
+test/fixtures/**/*.ts
+test/fixtures/**/*.json
 .vscode/launch.json
 
 # ts compiled

--- a/args.js
+++ b/args.js
@@ -8,7 +8,7 @@ module.exports = function parseArgs (args) {
       'populate--': true
     },
     number: ['port', 'inspect-port', 'body-limit', 'plugin-timeout'],
-    boolean: ['pretty-logs', 'options', 'watch', 'debug'],
+    boolean: ['pretty-logs', 'options', 'watch', 'debug', 'ts-watcher'],
     string: ['log-level', 'address', 'socket', 'prefix', 'ignore-watch', 'logging-module', 'debug-host', 'lang', 'tsconfig'],
     envPrefix: 'FASTIFY_',
     alias: {
@@ -36,7 +36,8 @@ module.exports = function parseArgs (args) {
       options: false,
       'plugin-timeout': 10 * 1000, // everything should load in 10 seconds
       lang: 'js',
-      tsconfig: 'tsconfig.json'
+      tsconfig: 'tsconfig.json',
+      'ts-watcher': true
     }
   })
 
@@ -63,6 +64,7 @@ module.exports = function parseArgs (args) {
     prefix: parsedArgs.prefix,
     loggingModule: parsedArgs.loggingModule,
     lang: parsedArgs.lang,
-    tsconfig: parsedArgs.tsconfig
+    tsconfig: parsedArgs.tsconfig,
+    tsWatcher: parsedArgs.tsWatcher
   }
 }

--- a/examples/nested-ts/child-project/src/plugin.ts
+++ b/examples/nested-ts/child-project/src/plugin.ts
@@ -1,0 +1,10 @@
+import { FastifyPluginAsync } from 'fastify'
+
+const root: FastifyPluginAsync = async (fastify, opts): Promise<void> => {
+  fastify.decorate('test', true)
+  fastify.get('/', async function (request, reply) {
+    return { hello: 'world' }
+  })
+}
+
+export default root;

--- a/examples/nested-ts/child-project/tsconfig.json
+++ b/examples/nested-ts/child-project/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "include": [
+    "src"
+  ],
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  }
+}

--- a/examples/nested-ts/tsconfig.json
+++ b/examples/nested-ts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "exclude": ["node_modules", "dist", "lib"],
+    "compilerOptions": {
+        "lib": ["es2019"],
+        "target": "es2019",
+        "module": "commonjs",
+        "rootDir": ".",
+        "outDir": "lib",
+        "resolveJsonModule": true,
+        "baseUrl": ".",
+        "moduleResolution": "node"
+    }
+}

--- a/lib/watch/tsc-watcher.js
+++ b/lib/watch/tsc-watcher.js
@@ -56,9 +56,12 @@ function watchMain (args, opts) {
     }
     origPostProgramCreate(program)
 
+    // We need to set the NODE_PATH variable in case node_modules are in a child directory
+    const env = Object.assign({}, process.env, { NODE_PATH: resolve(process.cwd(), 'node_modules') })
     child = cp.fork(forkPath, args, {
       cwd: process.cwd(),
-      encoding: 'utf8'
+      encoding: 'utf8',
+      env
     })
     let readyEmitted = false
 

--- a/lib/watch/tsc-watcher.js
+++ b/lib/watch/tsc-watcher.js
@@ -45,7 +45,7 @@ function watchMain (args, opts) {
   }
   const origPostProgramCreate = host.afterProgramCreate
 
-  const configFile = require(resolve(process.cwd(), configPath))
+  const configFile = requireTsConfig(resolve(process.cwd(), configPath))
 
   const appFile = join(resolve(dirname(configPath), configFile.compilerOptions.outDir), basename(opts._[0]).replace(/.ts$/, '.js'))
   args.splice(args.length - 1, 1, appFile)
@@ -99,6 +99,30 @@ function reportDiagnostic (diagnostic) {
 
 function reportWatchStatusChanged (diagnostic) {
   console.info(ts.formatDiagnostic(diagnostic, formatHost))
+}
+
+function requireTsConfig (configPath) {
+  const isModule = basename(configPath) === configPath
+  let configFile = require(isModule ? configPath : resolve(process.cwd(), configPath))
+  const parent = configFile.extends
+  if (configFile.compilerOptions.outDir) {
+    configFile.compilerOptions.outDir = resolve(dirname(configPath), configFile.compilerOptions.outDir)
+  }
+  if (parent) {
+    configFile = deepMergeConfig(requireTsConfig(parent), configFile)
+  }
+  return configFile
+}
+
+function deepMergeConfig (obj1, obj2) {
+  const result = Object.assign({}, obj1, obj2)
+  for (const key of Object.keys(result)) {
+    if (typeof result[key] === 'object' && !Array.isArray(result[key])) {
+      result[key] = deepMergeConfig(obj1[key], obj2[key])
+      continue
+    }
+  }
+  return result
 }
 
 module.exports = watchMain

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "fastify-tsconfig": "^1.0.0",
     "minimatch": "^3.0.4",
     "mkdirp": "^1.0.3",
+    "ncp": "^2.0.0",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.3",
     "rimraf": "^3.0.2",

--- a/start.js
+++ b/start.js
@@ -43,7 +43,7 @@ async function start (args) {
   // we start crashing on unhandledRejection
   require('make-promises-safe')
 
-  if (path.extname(opts._[0]) === '.ts' && opts.watch) {
+  if (path.extname(opts._[0]) === '.ts' && opts.watch && opts.tsWatcher) {
     return require('./lib/watch/tsc-watcher')(args, opts)
   }
 

--- a/start.js
+++ b/start.js
@@ -43,7 +43,7 @@ async function start (args) {
   // we start crashing on unhandledRejection
   require('make-promises-safe')
 
-  if (path.extname(opts._[0]) === '.ts') {
+  if (path.extname(opts._[0]) === '.ts' && opts.watch) {
     return require('./lib/watch/tsc-watcher')(args, opts)
   }
 

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -45,7 +45,8 @@ test('should parse args correctly', t => {
     debugHost: '1.1.1.1',
     loggingModule: './custom-logger.js',
     lang: 'js',
-    tsconfig: 'tsconfig.json'
+    tsconfig: 'tsconfig.json',
+    tsWatcher: true
   })
 })
 
@@ -92,7 +93,8 @@ test('should parse args with = assignment correctly', t => {
     debugHost: '1.1.1.1',
     loggingModule: './custom-logger.js',
     lang: 'js',
-    tsconfig: 'tsconfig.json'
+    tsconfig: 'tsconfig.json',
+    tsWatcher: true
   })
 })
 
@@ -154,7 +156,8 @@ test('should parse env vars correctly', t => {
     debugHost: '1.1.1.1',
     loggingModule: './custom-logger.js',
     lang: 'js',
-    tsconfig: 'tsconfig.json'
+    tsconfig: 'tsconfig.json',
+    tsWatcher: true
   })
 })
 
@@ -234,6 +237,7 @@ test('should parse custom plugin options', t => {
     debugHost: '1.1.1.1',
     loggingModule: './custom-logger.js',
     lang: 'js',
-    tsconfig: 'tsconfig.json'
+    tsconfig: 'tsconfig.json',
+    tsWatcher: true
   })
 })

--- a/test/tsconfig/tsconfig.base.json
+++ b/test/tsconfig/tsconfig.base.json
@@ -2,9 +2,10 @@
   "extends": "fastify-tsconfig",
   "compilerOptions": {
     "esModuleInterop": true,
-    "outDir": "dist"
+    "outDir": "../dist",
+    "rootDir": "../fixtures"
   },
   "include": [
-    "test/fixtures/**/*.ts"
+    "../fixtures/**/*.ts"
   ]
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


This is a proposal to fix #279 
This should fix 2 issues:
1) parent tsconfig are now included so now is possible to specify outDir in parent config
2) outDir is now relative to the config file where it is specified

Note
As you can see there is a failing test, this happens only when running together the tests of the suite `start-typescript.test.js` with error: `child test left in queue: t.test should start the server with watch option in nested dir`
No idea why

I also added a new option `ts-watcher` which can be set to false to allow the user to not watch ts files and to use something like `ts-node` together with fastify-cli watcher.

If we still decide to revert is not a problem off-course but I would still love to have your opinion on this if possible @mcollina and @fox1t (I'm here to learn after all :smile: ) 