### PR TITLE
fix: should throw error when async plugin is invalid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ test.sock
 test/workdir
 test/fixtures/*.js
 .vscode/launch.json
+.vscode/settings.json

--- a/test/data/async-plugin-with-one-argument.js
+++ b/test/data/async-plugin-with-one-argument.js
@@ -1,0 +1,6 @@
+'use strict'
+
+// This is a counter example. WILL NOT WORK!
+// we are creating an async plugin with only one argument
+module.exports = async function (fastify) {
+}

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -643,3 +643,16 @@ test('should throw on logger configuration module not found', async t => {
   await fastify.close()
   t.pass('server closed')
 })
+
+test('should throw on async plugin with one argument', async t => {
+  t.plan(1)
+
+  const oldStop = start.stop
+  t.tearDown(() => { start.stop = oldStop })
+  start.stop = function (err) {
+    t.ok(/Async\/Await plugin function should contain 2 arguments./.test(err.message), err.message)
+  }
+
+  const argv = ['./test/data/async-plugin-with-one-argument.js']
+  start.start(argv)
+})

--- a/util.js
+++ b/util.js
@@ -40,7 +40,7 @@ function requireServerPluginFromPath (modulePath) {
   const serverPlugin = require(resolvedModulePath)
 
   if (isInvalidAsyncPlugin(serverPlugin)) {
-    return new Error('Async/Await plugin function should contain 2 arguments.' +
+    throw new Error('Async/Await plugin function should contain 2 arguments. ' +
       'Refer to documentation for more information.')
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Error was being returned, leading to a misleading error displayed when starting the plugin using fastify-cli.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
