### PR TITLE
docs(help/generate.txt, readme): add generate command typescript template info

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,13 @@ This will add or alter the `main`, `scripts`, `dependencies` and `devDependencie
 for any files being added, the file will be overwritten with the new file added by generate. So if there is an existing `app.js` in this scenario,
 it will be overwritten. Use the `--integrate` flag with care.
 
+#### Options
+
+| Description | Full command |
+| --- | --- |
+| Use the TypeScript template | `--lang=ts`, `--lang=typescript` |
+| Overwrite it when the target directory is the current directory (`.`) | `--integrate`|
+
 ### generate-plugin
 
 `fastify-cli` can help you improve your plugin development by generating a scaffolding project:

--- a/help/generate.txt
+++ b/help/generate.txt
@@ -3,3 +3,11 @@ Usage: fastify generate <FOLDER>
 Sets up project with `npm init -y` and
 generates a sample Fastify project
 in the <FOLDER>. Specify `.` to create files in the current working directory.
+
+OPTS
+
+  --integrate
+      overwrite it when the target directory is the current directory (.)
+
+  --lang=ts, --lang=typescript
+      use the TypeScript template


### PR DESCRIPTION
Hi 👋 Thanks for the awesome CLI!

I want to gen a TS project and noticed there is a `templates/app-ts` template in this project.
But I run through `README.md` and there no info about it. Even I run `fastify help generate` still so.
So I add a little info to help cmd & README.md. Please let me know if I need to correct any mistakes or omissions.
Thank you!

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
