### PR TITLE
Fix eject and eject-ts tests

### DIFF
--- a/eject-ts.js
+++ b/eject-ts.js
@@ -4,27 +4,27 @@ const path = require('path')
 const generify = require('generify')
 const log = require('./log')
 
-function eject () {
+function eject (dir) {
   return new Promise((resolve, reject) => {
     generify(
       path.join(__dirname, 'templates', 'eject-ts'),
-      '.',
+      dir,
       {},
       function (file) {
         log('debug', `generated ${file}`)
-        resolve()
       },
       function (err) {
         if (err) {
           return reject(err)
         }
+        resolve()
       }
     )
   })
 }
 
 function cli () {
-  eject().catch(function (err) {
+  eject(process.cwd()).catch(function (err) {
     if (err) {
       log('error', err.message)
       process.exit(1)

--- a/eject.js
+++ b/eject.js
@@ -4,21 +4,21 @@ const path = require('path')
 const generify = require('generify')
 const log = require('./log')
 
-function eject () {
+function eject (dir) {
   return new Promise((resolve, reject) => {
-    generify(path.join(__dirname, 'templates', 'eject'), '.', {}, function (file) {
+    generify(path.join(__dirname, 'templates', 'eject'), dir, {}, function (file) {
       log('debug', `generated ${file}`)
-      resolve()
     }, function (err) {
       if (err) {
         return reject(err)
       }
+      resolve()
     })
   })
 }
 
 function cli () {
-  eject().catch(function (err) {
+  eject(process.cwd()).catch(function (err) {
     if (err) {
       log('error', err.message)
       process.exit(1)

--- a/test/eject-ts.test.js
+++ b/test/eject-ts.test.js
@@ -60,7 +60,7 @@ function define (t) {
 
   test('should finish succesfully with template', async (t) => {
     try {
-      await eject()
+      await eject(workdir)
       await verifyCopy(t, expected)
     } catch (err) {
       t.error(err)
@@ -69,8 +69,10 @@ function define (t) {
 
   function verifyCopy (t, expected) {
     return new Promise((resolve, reject) => {
+      let count = 0
       walker(workdir)
         .on('file', function (file) {
+          count++
           try {
             const data = readFileSync(file)
             file = file.replace(workdir, '')
@@ -84,6 +86,7 @@ function define (t) {
           }
         })
         .on('end', function () {
+          t.equal(Object.keys(expected).length, count)
           resolve()
         })
         .on('error', function (err, entry, stat) {

--- a/test/eject.test.js
+++ b/test/eject.test.js
@@ -61,7 +61,7 @@ function define (t) {
 
   test('should finish succesfully with template', async (t) => {
     try {
-      await eject()
+      await eject(workdir)
       await verifyCopy(t, expected)
     } catch (err) {
       t.error(err)
@@ -70,8 +70,10 @@ function define (t) {
 
   function verifyCopy (t, expected) {
     return new Promise((resolve, reject) => {
+      let count = 0
       walker(workdir)
         .on('file', function (file) {
+          count++
           try {
             const data = readFileSync(file)
             file = file.replace(workdir, '')
@@ -81,6 +83,7 @@ function define (t) {
           }
         })
         .on('end', function () {
+          t.equal(Object.keys(expected).length, count)
           resolve()
         })
         .on('error', function (err, entry, stat) {


### PR DESCRIPTION
Fixes the eject and eject-ts tests and implementation

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
