### PR TITLE
Add option to load module before anything else #314

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ You can pass the following options via cli arguments, every options has the corr
 | Port to listen on (default to 3000)                                                                                                     | `-p`          | `--port`           | `FASTIFY_PORT or PORT`   |
 | Address to listen on                                                                                                                    | `-a`          | `--address`        | `FASTIFY_ADDRESS`        |
 | Socket to listen on                                                                                                                     | `-s`          | `--socket`         | `FASTIFY_SOCKET`         |
-| Path to module to run before anything else                                                                                              | `-b`          | `--before-module`  | `FASTIFY_BEFORE_MODULE`  |
+| Module to preload                                                                                                                       | `-r`          | `--require`        | `FASTIFY_REQUIRE`        |
 | Log level (default to fatal)                                                                                                            | `-l`          | `--log-level`      | `FASTIFY_LOG_LEVEL`      |
 | Start fastify app in debug mode with nodejs inspector                                                                                   | `-d`          | `--debug`          | `FASTIFY_DEBUG`          |
 | Set the inspector port (default: 9320)                                                                                                  | `-I`          | `--debug-port`     | `FASTIFY_DEBUG_PORT`     |
@@ -138,7 +138,7 @@ You can pass the following options via cli arguments, every options has the corr
 | Watch process.cwd() directory for changes, recursively; when that happens, the process will auto reload.                                | `-w`          | `--watch`          | `FASTIFY_WATCH`          |
 | Ignore changes to the specified files or directories when watch is enabled. (e.g. `--ignore-watch='node_modules .git logs/error.log'` ) |               | `--ignore-watch`   | `FASTIFY_IGNORE_WATCH`   |
 | Use custom options                                                                                                                      | `-o`          | `--options`        | `FASTIFY_OPTIONS`        |
-| Set the prefix                                                                                                                          | `-r`          | `--prefix`         | `FASTIFY_PREFIX`         |
+| Set the prefix                                                                                                                          | `-x`          | `--prefix`         | `FASTIFY_PREFIX`         |
 | Set the plugin timeout                                                                                                                  | `-T`          | `--plugin-timeout` | `FASTIFY_PLUGIN_TIMEOUT` |
 | Defines the maximum payload, in bytes,<br>the server is allowed to accept                                                               |               | `--body-limit`     | `FASTIFY_BODY_LIMIT`     |
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ You can pass the following options via cli arguments, every options has the corr
 | Port to listen on (default to 3000)                                                                                                     | `-p`          | `--port`           | `FASTIFY_PORT or PORT`   |
 | Address to listen on                                                                                                                    | `-a`          | `--address`        | `FASTIFY_ADDRESS`        |
 | Socket to listen on                                                                                                                     | `-s`          | `--socket`         | `FASTIFY_SOCKET`         |
+| Path to module to run before anything else                                                                                              | `-b`          | `--before-module`  | `FASTIFY_BEFORE_MODULE`  |
 | Log level (default to fatal)                                                                                                            | `-l`          | `--log-level`      | `FASTIFY_LOG_LEVEL`      |
 | Start fastify app in debug mode with nodejs inspector                                                                                   | `-d`          | `--debug`          | `FASTIFY_DEBUG`          |
 | Set the inspector port (default: 9320)                                                                                                  | `-I`          | `--debug-port`     | `FASTIFY_DEBUG_PORT`     |

--- a/args.js
+++ b/args.js
@@ -9,7 +9,7 @@ module.exports = function parseArgs (args) {
     },
     number: ['port', 'inspect-port', 'body-limit', 'plugin-timeout'],
     boolean: ['pretty-logs', 'options', 'watch', 'debug'],
-    string: ['log-level', 'address', 'socket', 'prefix', 'ignore-watch', 'logging-module', 'debug-host', 'lang'],
+    string: ['log-level', 'address', 'socket', 'prefix', 'ignore-watch', 'logging-module', 'debug-host', 'lang', 'before-module'],
     envPrefix: 'FASTIFY_',
     alias: {
       port: ['p'],
@@ -19,6 +19,7 @@ module.exports = function parseArgs (args) {
       address: ['a'],
       watch: ['w'],
       prefix: ['r'],
+      'before-module': ['b'],
       debug: ['d'],
       'debug-port': ['I'],
       'log-level': ['l'],
@@ -59,6 +60,7 @@ module.exports = function parseArgs (args) {
     logLevel: parsedArgs.logLevel,
     address: parsedArgs.address,
     socket: parsedArgs.socket,
+    beforeModule: parsedArgs.beforeModule,
     prefix: parsedArgs.prefix,
     loggingModule: parsedArgs.loggingModule,
     lang: parsedArgs.lang

--- a/args.js
+++ b/args.js
@@ -9,7 +9,7 @@ module.exports = function parseArgs (args) {
     },
     number: ['port', 'inspect-port', 'body-limit', 'plugin-timeout'],
     boolean: ['pretty-logs', 'options', 'watch', 'debug'],
-    string: ['log-level', 'address', 'socket', 'prefix', 'ignore-watch', 'logging-module', 'debug-host', 'lang', 'before-module'],
+    string: ['log-level', 'address', 'socket', 'prefix', 'ignore-watch', 'logging-module', 'debug-host', 'lang', 'require'],
     envPrefix: 'FASTIFY_',
     alias: {
       port: ['p'],
@@ -18,8 +18,8 @@ module.exports = function parseArgs (args) {
       options: ['o'],
       address: ['a'],
       watch: ['w'],
-      prefix: ['r'],
-      'before-module': ['b'],
+      prefix: ['x'],
+      require: ['r'],
       debug: ['d'],
       'debug-port': ['I'],
       'log-level': ['l'],
@@ -60,7 +60,7 @@ module.exports = function parseArgs (args) {
     logLevel: parsedArgs.logLevel,
     address: parsedArgs.address,
     socket: parsedArgs.socket,
-    beforeModule: parsedArgs.beforeModule,
+    require: parsedArgs.require,
     prefix: parsedArgs.prefix,
     loggingModule: parsedArgs.loggingModule,
     lang: parsedArgs.lang

--- a/examples/plugin-with-preloaded.js
+++ b/examples/plugin-with-preloaded.js
@@ -1,0 +1,12 @@
+/* global GLOBAL_MODULE_1 */
+'use strict'
+const t = require('tap')
+
+module.exports = async function (fastify, options) {
+  fastify.get('/', async function (req, reply) {
+    return { hasPreloaded: GLOBAL_MODULE_1 }
+  })
+  fastify.addHook('onReady', function () {
+    t.ok(GLOBAL_MODULE_1)
+  })
+}

--- a/help/start.txt
+++ b/help/start.txt
@@ -18,6 +18,10 @@ OPTS
   [env: FASTIFY_LOG_LEVEL]
       Log level (default to fatal)
 
+  -b, --before-module
+  [env: FASTIFY_BEFORE_MODULE]
+      Path to module to run before anything else
+
   -L, --logging-module
   [env: FASTIFY_LOGGING_MODULE]
       Path to logging configuration module to use

--- a/help/start.txt
+++ b/help/start.txt
@@ -18,9 +18,9 @@ OPTS
   [env: FASTIFY_LOG_LEVEL]
       Log level (default to fatal)
 
-  -b, --before-module
-  [env: FASTIFY_BEFORE_MODULE]
-      Path to module to run before anything else
+  -r, --require
+  [env: FASTIFY_REQUIRE]
+      Module to preload
 
   -L, --logging-module
   [env: FASTIFY_LOGGING_MODULE]
@@ -38,7 +38,7 @@ OPTS
   [env: FASTIFY_WATCH]
       Watch process.cwd() directory for changes, recursively; when that happens, the process will auto reload.
 
-  -r, --prefix
+  -x, --prefix
   [env: FASTIFY_PREFIX]
       Set the prefix
 

--- a/start.js
+++ b/start.js
@@ -12,10 +12,10 @@ const watch = require('./lib/watch')
 const parseArgs = require('./args')
 const {
   exit,
+  requirePath,
   requireFastifyForModule,
   requireServerPluginFromPath,
-  showHelpForCommand,
-  requireModule
+  showHelpForCommand
 } = require('./util')
 
 let Fastify = null
@@ -60,15 +60,13 @@ function stop (message) {
 async function runFastify (args) {
   require('dotenv').config()
   const opts = parseArgs(args)
-
-  if (opts.beforeModule) {
+  if (opts.require) {
     try {
-      await requireModule(opts.beforeModule)
+      requirePath(opts.require)
     } catch (e) {
-      return module.exports.stop(e)
+      module.exports.stop(e)
     }
   }
-
   opts.port = opts.port || process.env.PORT || 3000
 
   loadModules(opts)
@@ -84,7 +82,7 @@ async function runFastify (args) {
   let logger
   if (opts.loggingModule) {
     try {
-      logger = await requireModule(opts.loggingModule)
+      logger = requirePath(opts.loggingModule)
     } catch (e) {
       module.exports.stop(e)
     }

--- a/start.js
+++ b/start.js
@@ -61,8 +61,19 @@ async function runFastify (args) {
   require('dotenv').config()
   const opts = parseArgs(args)
   if (opts.require) {
+    if (typeof opts.require === 'string') {
+      opts.require = [opts.require]
+    }
+
     try {
-      requirePath(opts.require)
+      opts.require.forEach(module => {
+        if (module) {
+          /* This check ensures we ignore `-r ""`, trailing `-r`, or
+           * other silly things the user might (inadvertently) be doing.
+           */
+          requirePath(module)
+        }
+      })
     } catch (e) {
       module.exports.stop(e)
     }

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -9,6 +9,7 @@ test('should parse args correctly', t => {
     '--port', '7777',
     '--address', 'fastify.io:9999',
     '--socket', 'fastify.io.socket:9999',
+    '--before-module', './before-module.js',
     '--log-level', 'info',
     '--pretty-logs', 'true',
     '--watch', 'true',
@@ -35,6 +36,7 @@ test('should parse args correctly', t => {
     port: 7777,
     address: 'fastify.io:9999',
     socket: 'fastify.io.socket:9999',
+    beforeModule: './before-module.js',
     logLevel: 'info',
     prefix: 'FASTIFY_',
     pluginTimeout: 500,
@@ -55,6 +57,7 @@ test('should parse args with = assignment correctly', t => {
     '--port=7777',
     '--address=fastify.io:9999',
     '--socket=fastify.io.socket:9999',
+    '--before-module', './before-module.js',
     '--log-level=info',
     '--pretty-logs=true',
     '--watch=true',
@@ -81,6 +84,7 @@ test('should parse args with = assignment correctly', t => {
     port: 7777,
     address: 'fastify.io:9999',
     socket: 'fastify.io.socket:9999',
+    beforeModule: './before-module.js',
     logLevel: 'info',
     prefix: 'FASTIFY_',
     pluginTimeout: 500,
@@ -100,6 +104,7 @@ test('should parse env vars correctly', t => {
   process.env.FASTIFY_PORT = '7777'
   process.env.FASTIFY_ADDRESS = 'fastify.io:9999'
   process.env.FASTIFY_SOCKET = 'fastify.io.socket:9999'
+  process.env.FASTIFY_BEFORE_MODULE = './before-module.js'
   process.env.FASTIFY_LOG_LEVEL = 'info'
   process.env.FASTIFY_PRETTY_LOGS = 'true'
   process.env.FASTIFY_WATCH = 'true'
@@ -117,6 +122,7 @@ test('should parse env vars correctly', t => {
     delete process.env.FASTIFY_PORT
     delete process.env.FASTIFY_ADDRESS
     delete process.env.FASTIFY_SOCKET
+    delete process.env.FASTIFY_BEFORE_MODULE
     delete process.env.FASTIFY_LOG_LEVEL
     delete process.env.FASTIFY_PRETTY_LOGS
     delete process.env.FASTIFY_WATCH
@@ -145,6 +151,7 @@ test('should parse env vars correctly', t => {
     port: 7777,
     prefix: 'FASTIFY_',
     socket: 'fastify.io.socket:9999',
+    beforeModule: './before-module.js',
     pluginTimeout: 500,
     pluginOptions: {},
     debug: true,
@@ -156,7 +163,7 @@ test('should parse env vars correctly', t => {
 })
 
 test('should respect default values', t => {
-  t.plan(10)
+  t.plan(11)
 
   const argv = [
     'app.js'
@@ -174,6 +181,7 @@ test('should respect default values', t => {
   t.is(parsedArgs.debug, false)
   t.is(parsedArgs.debugPort, 9320)
   t.is(parsedArgs.loggingModule, undefined)
+  t.is(parsedArgs.beforeModule, undefined)
 })
 
 test('should parse custom plugin options', t => {
@@ -183,6 +191,7 @@ test('should parse custom plugin options', t => {
     '--port', '7777',
     '--address', 'fastify.io:9999',
     '--socket', 'fastify.io.socket:9999',
+    '--before-module', './before-module.js',
     '--log-level', 'info',
     '--pretty-logs', 'true',
     '--watch', 'true',
@@ -216,6 +225,7 @@ test('should parse custom plugin options', t => {
     port: 7777,
     address: 'fastify.io:9999',
     socket: 'fastify.io.socket:9999',
+    beforeModule: './before-module.js',
     logLevel: 'info',
     prefix: 'FASTIFY_',
     pluginTimeout: 500,

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -9,7 +9,7 @@ test('should parse args correctly', t => {
     '--port', '7777',
     '--address', 'fastify.io:9999',
     '--socket', 'fastify.io.socket:9999',
-    '--before-module', './before-module.js',
+    '--require', './require-module.js',
     '--log-level', 'info',
     '--pretty-logs', 'true',
     '--watch', 'true',
@@ -36,7 +36,7 @@ test('should parse args correctly', t => {
     port: 7777,
     address: 'fastify.io:9999',
     socket: 'fastify.io.socket:9999',
-    beforeModule: './before-module.js',
+    require: './require-module.js',
     logLevel: 'info',
     prefix: 'FASTIFY_',
     pluginTimeout: 500,
@@ -57,7 +57,7 @@ test('should parse args with = assignment correctly', t => {
     '--port=7777',
     '--address=fastify.io:9999',
     '--socket=fastify.io.socket:9999',
-    '--before-module', './before-module.js',
+    '--require', './require-module.js',
     '--log-level=info',
     '--pretty-logs=true',
     '--watch=true',
@@ -84,7 +84,7 @@ test('should parse args with = assignment correctly', t => {
     port: 7777,
     address: 'fastify.io:9999',
     socket: 'fastify.io.socket:9999',
-    beforeModule: './before-module.js',
+    require: './require-module.js',
     logLevel: 'info',
     prefix: 'FASTIFY_',
     pluginTimeout: 500,
@@ -104,7 +104,7 @@ test('should parse env vars correctly', t => {
   process.env.FASTIFY_PORT = '7777'
   process.env.FASTIFY_ADDRESS = 'fastify.io:9999'
   process.env.FASTIFY_SOCKET = 'fastify.io.socket:9999'
-  process.env.FASTIFY_BEFORE_MODULE = './before-module.js'
+  process.env.FASTIFY_REQUIRE = './require-module.js'
   process.env.FASTIFY_LOG_LEVEL = 'info'
   process.env.FASTIFY_PRETTY_LOGS = 'true'
   process.env.FASTIFY_WATCH = 'true'
@@ -122,7 +122,7 @@ test('should parse env vars correctly', t => {
     delete process.env.FASTIFY_PORT
     delete process.env.FASTIFY_ADDRESS
     delete process.env.FASTIFY_SOCKET
-    delete process.env.FASTIFY_BEFORE_MODULE
+    delete process.env.FASTIFY_REQUIRE
     delete process.env.FASTIFY_LOG_LEVEL
     delete process.env.FASTIFY_PRETTY_LOGS
     delete process.env.FASTIFY_WATCH
@@ -151,7 +151,7 @@ test('should parse env vars correctly', t => {
     port: 7777,
     prefix: 'FASTIFY_',
     socket: 'fastify.io.socket:9999',
-    beforeModule: './before-module.js',
+    require: './require-module.js',
     pluginTimeout: 500,
     pluginOptions: {},
     debug: true,
@@ -181,7 +181,7 @@ test('should respect default values', t => {
   t.is(parsedArgs.debug, false)
   t.is(parsedArgs.debugPort, 9320)
   t.is(parsedArgs.loggingModule, undefined)
-  t.is(parsedArgs.beforeModule, undefined)
+  t.is(parsedArgs.require, undefined)
 })
 
 test('should parse custom plugin options', t => {
@@ -191,7 +191,7 @@ test('should parse custom plugin options', t => {
     '--port', '7777',
     '--address', 'fastify.io:9999',
     '--socket', 'fastify.io.socket:9999',
-    '--before-module', './before-module.js',
+    '--require', './require-module.js',
     '--log-level', 'info',
     '--pretty-logs', 'true',
     '--watch', 'true',
@@ -225,7 +225,7 @@ test('should parse custom plugin options', t => {
     port: 7777,
     address: 'fastify.io:9999',
     socket: 'fastify.io.socket:9999',
-    beforeModule: './before-module.js',
+    require: './require-module.js',
     logLevel: 'info',
     prefix: 'FASTIFY_',
     pluginTimeout: 500,

--- a/test/data/custom-require.js
+++ b/test/data/custom-require.js
@@ -1,0 +1,3 @@
+/* global GLOBAL_MODULE_1 */
+GLOBAL_MODULE_1 = true // eslint-disable-line
+console.log('this is module to be preloaded that sets GLOBAL_MODULE_1=', GLOBAL_MODULE_1)

--- a/test/data/custom-require2.js
+++ b/test/data/custom-require2.js
@@ -1,0 +1,3 @@
+/* global GLOBAL_MODULE_2 */
+GLOBAL_MODULE_2 = true // eslint-disable-line
+console.log('this is module to be preloaded that sets GLOBAL_MODULE_2=', GLOBAL_MODULE_2)

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -187,7 +187,7 @@ test('should start fastify with custom plugin options with a typescript compiled
 test('should start the server at the given prefix', async t => {
   t.plan(4)
 
-  const argv = ['-p', getPort(), '-r', '/api/hello', './examples/plugin.js']
+  const argv = ['-p', getPort(), '-x', '/api/hello', './examples/plugin.js']
   const fastify = await start.start(argv)
 
   const { response, body } = await sget({
@@ -679,7 +679,7 @@ test('should throw on logger configuration module not found', async t => {
   const oldStop = start.stop
   t.tearDown(() => { start.stop = oldStop })
   start.stop = function (err) {
-    t.ok(/doesn't exist within/.test(err.message), err.message)
+    t.ok(/Cannot find module/.test(err.message), err.message)
   }
 
   const argv = ['-L', './test/data/missing.js', './examples/plugin.js']

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -679,7 +679,7 @@ test('should throw on logger configuration module not found', async t => {
   const oldStop = start.stop
   t.tearDown(() => { start.stop = oldStop })
   start.stop = function (err) {
-    t.ok(/Cannot find module/.test(err.message), err.message)
+    t.ok(/doesn't exist within/.test(err.message), err.message)
   }
 
   const argv = ['-L', './test/data/missing.js', './examples/plugin.js']

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -713,6 +713,25 @@ test('preloading custom module that is not found should throw', async t => {
   t.pass('server closed')
 })
 
+test('preloading custom module should be done before starting server', async t => {
+  t.plan(4)
+
+  const argv = ['./examples/plugin-with-preloaded.js']
+  const fastify = await start.start(argv)
+
+  const { response, body } = await sget({
+    method: 'GET',
+    url: `http://localhost:${fastify.server.address().port}`
+  })
+
+  t.strictEqual(response.statusCode, 200)
+  t.strictEqual(response.headers['content-length'], '' + body.length)
+  t.deepEqual(JSON.parse(body), { hasPreloaded: true })
+
+  await fastify.close()
+  t.pass('server closed')
+})
+
 test('should support custom logger configuration', async t => {
   t.plan(2)
 

--- a/util.js
+++ b/util.js
@@ -47,7 +47,7 @@ function getScriptType (fname, packageType) {
   return (modulePattern.test(fname) ? 'module' : commonjsPattern.test(fname) ? 'commonjs' : packageType) || 'commonjs'
 }
 
-async function requireServerPluginFromPath (modulePath) {
+async function requireModule (modulePath) {
   const resolvedModulePath = path.resolve(process.cwd(), modulePath)
 
   if (!fs.existsSync(resolvedModulePath)) {
@@ -62,11 +62,18 @@ async function requireServerPluginFromPath (modulePath) {
     if (moduleSupport) {
       serverPlugin = (await import(url.pathToFileURL(resolvedModulePath).href)).default
     } else {
-      throw new Error(`fastify-cli cannot import plugin at '${resolvedModulePath}'. Your version of node does not support ES modules. To fix this error upgrade to Node 14 or use CommonJS syntax.`)
+      throw new Error(`fastify-cli cannot import module at '${resolvedModulePath}'. Your version of node does not support ES modules. To fix this error upgrade to Node 14 or use CommonJS syntax.`)
     }
   } else {
     serverPlugin = require(resolvedModulePath)
+    return serverPlugin
   }
+
+  return serverPlugin
+}
+
+async function requireServerPluginFromPath (modulePath) {
+  const serverPlugin = await requireModule(modulePath)
 
   if (isInvalidAsyncPlugin(serverPlugin)) {
     throw new Error('Async/Await plugin function should contain 2 arguments. ' +
@@ -87,4 +94,4 @@ function showHelpForCommand (commandName) {
   }
 }
 
-module.exports = { exit, requireFastifyForModule, showHelpForCommand, requireServerPluginFromPath }
+module.exports = { exit, requireModule, requireFastifyForModule, showHelpForCommand, requireServerPluginFromPath }

--- a/util.js
+++ b/util.js
@@ -19,6 +19,14 @@ function exit (message) {
   process.exit()
 }
 
+function requirePath (filePath) {
+  const moduleFilePath = path.resolve(filePath)
+  const moduleFileExtension = path.extname(filePath)
+  const modulePath = moduleFilePath.split(moduleFileExtension)[0]
+  const module = require(modulePath)
+  return module
+}
+
 function requireFastifyForModule (modulePath) {
   try {
     const basedir = path.resolve(process.cwd(), modulePath)
@@ -47,7 +55,7 @@ function getScriptType (fname, packageType) {
   return (modulePattern.test(fname) ? 'module' : commonjsPattern.test(fname) ? 'commonjs' : packageType) || 'commonjs'
 }
 
-async function requireModule (modulePath) {
+async function requireServerPluginFromPath (modulePath) {
   const resolvedModulePath = path.resolve(process.cwd(), modulePath)
 
   if (!fs.existsSync(resolvedModulePath)) {
@@ -62,18 +70,11 @@ async function requireModule (modulePath) {
     if (moduleSupport) {
       serverPlugin = (await import(url.pathToFileURL(resolvedModulePath).href)).default
     } else {
-      throw new Error(`fastify-cli cannot import module at '${resolvedModulePath}'. Your version of node does not support ES modules. To fix this error upgrade to Node 14 or use CommonJS syntax.`)
+      throw new Error(`fastify-cli cannot import plugin at '${resolvedModulePath}'. Your version of node does not support ES modules. To fix this error upgrade to Node 14 or use CommonJS syntax.`)
     }
   } else {
     serverPlugin = require(resolvedModulePath)
-    return serverPlugin
   }
-
-  return serverPlugin
-}
-
-async function requireServerPluginFromPath (modulePath) {
-  const serverPlugin = await requireModule(modulePath)
 
   if (isInvalidAsyncPlugin(serverPlugin)) {
     throw new Error('Async/Await plugin function should contain 2 arguments. ' +
@@ -94,4 +95,4 @@ function showHelpForCommand (commandName) {
   }
 }
 
-module.exports = { exit, requireModule, requireFastifyForModule, showHelpForCommand, requireServerPluginFromPath }
+module.exports = { exit, requirePath, requireFastifyForModule, showHelpForCommand, requireServerPluginFromPath }


### PR DESCRIPTION
As described in #314.

Some notes:
- `-r` option was already in use for `prefix` so took `b`/`before-module` (like existing `logging-module` option). Feel free to request other naming if preferred.
- Requiring the actual module seemed exactly the same as the existing `logging-module`. In an effort to create a function out of it, I abstracted the core part of `util.js's` `requireServerPluginFromPath` to `requireModule`. This leads to some minor differences in textual error output. Behavior of when errors are thrown is still the same though.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
