### PR TITLE
Change .mjs to .js and add note about "type": "module"

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,9 @@ export default async function plugin (fastify, options) {
 }
 ```
 
-(You need to set `"type": "module"` in `package.json` for this to work with a `.js`
-extension, otherwise use `.mjs`)
+This works with a `.js` extension if you are using Node.js >= 14 and the nearest parent `package.json` has `"type": "module"`
+([more info here](https://nodejs.medium.com/announcing-core-node-js-support-for-ecmascript-modules-c5d6dc29b663)).
+If your `package.json` does not have `"type": "module"`, use `.mjs` for the extension (`plugin.mjs` in the above example).
 
 #### Options
 You can pass the following options via cli arguments, every options has the corresponding environment variable:

--- a/README.md
+++ b/README.md
@@ -113,13 +113,16 @@ $ fastify start plugin.js -- --one
 
 Modules in EcmaScript Module format can be used on Node.js >= 14 or >= 12.17.0 but < 13.0.0'
 ```js
-// plugin.mjs
+// plugin.js
 export default async function plugin (fastify, options) {
   fastify.get('/', async function (req, reply) {
     return options
   })
 }
 ```
+
+(You need to set `"type": "module"` in `package.json` for this to work with a `.js`
+extension, otherwise use `.mjs`)
 
 #### Options
 You can pass the following options via cli arguments, every options has the corresponding environment variable:


### PR DESCRIPTION
`fastify-cli` is really cool! I want to use esnext with no build step for my current project, and was glad to find that fastify-cli has no conflict with node's new ability to run es modules with a `.js` extension when `"type": "module"` is set in package.json