### PR TITLE
keep dotenv at top in order for watch env variable to be parsed before start

### DIFF
--- a/start.js
+++ b/start.js
@@ -2,6 +2,8 @@
 
 'use strict'
 
+require('dotenv').config() // keep at top in order for watch env variable to be parsed before start
+
 const assert = require('assert')
 const split = require('split2')
 const PinoColada = require('pino-colada')
@@ -59,7 +61,6 @@ function stop (message) {
 }
 
 async function runFastify (args) {
-  require('dotenv').config()
   const opts = parseArgs(args)
   if (opts.require) {
     if (typeof opts.require === 'string') {

--- a/start.js
+++ b/start.js
@@ -61,6 +61,7 @@ function stop (message) {
 }
 
 async function runFastify (args) {
+  require('dotenv').config() //reload env when watch restarts the application #300
   const opts = parseArgs(args)
   if (opts.require) {
     if (typeof opts.require === 'string') {


### PR DESCRIPTION

https://github.com/fastify/fastify-cli/issues/327

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
