### PR TITLE
fix: make both fastify and plugin env vars work

### DIFF
--- a/lib/watch/index.js
+++ b/lib/watch/index.js
@@ -39,7 +39,7 @@ const watch = function (args, ignoreWatch, verboseWatch) {
 
   const run = (event) => {
     const childEvent = { childEvent: event }
-    const env = Object.assign({}, process.env, childEvent)
+    const env = Object.assign({}, process.env, childEvent, require('dotenv').config().parsed)
 
     const _child = cp.fork(forkPath, args, {
       env: env,

--- a/start.js
+++ b/start.js
@@ -2,6 +2,7 @@
 
 'use strict'
 
+require('dotenv').config()
 const assert = require('assert')
 const split = require('split2')
 const PinoColada = require('pino-colada')
@@ -59,7 +60,6 @@ function stop (message) {
 }
 
 async function runFastify (args) {
-  require('dotenv').config()
   const opts = parseArgs(args)
   if (opts.require) {
     if (typeof opts.require === 'string') {


### PR DESCRIPTION
Fixes #327 

This change makes `fastify start` work for both scenarios:

1. using FASTIFY_* env vars from `.env` file, e.g. `FASTIFY_WATCH`
2. support reloading after `.env` file change in watch mode so that the app sees the updated env vars

### Why?

- the version before #300 was loading `.env` at `start.js` module initialization, thereby supporting only case 1) and not case 2) because even if the module is reloaded within the same process, dotenv doesn't overwrite env vars which are already set
- the version after #300 was loading `.env` too late, thereby supporting only case 2) but not case 1)

### What's missing

- an automated test, which is not straightforward to write

### How to test manually

- `cd examples`
- add `FASTIFY_WATCH=true` to `.env`
- `node ../cli.js start plugin-with-env.js` (note we're not providing `-w`)
- see that changing the value of `GREETING` in `.env` reloads the app (meaning that 1) is supported) and that the change in `GREETING` is reflected in the response of the app running at localhost:3000 (which shows that case 2) works)

Without the change in this PR, either of the 2 cases won't work.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
