### PR TITLE
allow preloading modules without referencing by filename

### DIFF
--- a/start.js
+++ b/start.js
@@ -14,7 +14,7 @@ const watch = require('./lib/watch')
 const parseArgs = require('./args')
 const {
   exit,
-  requirePath,
+  requireModule,
   requireFastifyForModule,
   requireServerPluginFromPath,
   showHelpForCommand
@@ -72,7 +72,7 @@ async function runFastify (args) {
           /* This check ensures we ignore `-r ""`, trailing `-r`, or
            * other silly things the user might (inadvertently) be doing.
            */
-          requirePath(module)
+          requireModule(module)
         }
       })
     } catch (e) {
@@ -94,7 +94,7 @@ async function runFastify (args) {
   let logger
   if (opts.loggingModule) {
     try {
-      logger = requirePath(opts.loggingModule)
+      logger = requireModule(opts.loggingModule)
     } catch (e) {
       module.exports.stop(e)
     }

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -821,6 +821,24 @@ test('should support custom logger configuration', async t => {
   t.pass('server closed')
 })
 
+test('preloading a built-in module works', async t => {
+  t.plan(1)
+
+  const argv = ['-r', 'path', './examples/plugin.js']
+  const fastify = await start.start(argv)
+  await fastify.close()
+  t.pass('server closed')
+})
+
+test('preloading a module in node_modules works', async t => {
+  t.plan(1)
+
+  const argv = ['-r', 'tap', './examples/plugin.js']
+  const fastify = await start.start(argv)
+  await fastify.close()
+  t.pass('server closed')
+})
+
 test('should throw on logger configuration module not found', async t => {
   t.plan(2)
 

--- a/util.js
+++ b/util.js
@@ -19,12 +19,15 @@ function exit (message) {
   process.exit()
 }
 
-function requirePath (filePath) {
-  const moduleFilePath = path.resolve(filePath)
-  const moduleFileExtension = path.extname(filePath)
-  const modulePath = moduleFilePath.split(moduleFileExtension)[0]
-  const module = require(modulePath)
-  return module
+function requireModule (moduleName) {
+  if (fs.existsSync(moduleName)) {
+    const moduleFilePath = path.resolve(moduleName)
+    const moduleFileExtension = path.extname(moduleName)
+    const modulePath = moduleFilePath.split(moduleFileExtension)[0]
+    return require(modulePath)
+  } else {
+    return require(moduleName)
+  }
 }
 
 function requireFastifyForModule (modulePath) {
@@ -95,4 +98,4 @@ function showHelpForCommand (commandName) {
   }
 }
 
-module.exports = { exit, requirePath, requireFastifyForModule, showHelpForCommand, requireServerPluginFromPath }
+module.exports = { exit, requireModule, requireFastifyForModule, showHelpForCommand, requireServerPluginFromPath }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

* Tries to fix #357 by leaving the current logic intact
* First checks if the provided module name is an existing file - if not - just use `require(id)`
