### PR TITLE
fix all test deprecations

### DIFF
--- a/templates/app-ts/test/helper.ts
+++ b/templates/app-ts/test/helper.ts
@@ -24,7 +24,7 @@ async function build (t: Test) {
   await app.ready();
 
   // Tear down our app after we are done
-  t.tearDown(() => void app.close())
+  t.teardown(() => void app.close())
 
   return app
 }

--- a/templates/app-ts/test/routes/root.test.ts
+++ b/templates/app-ts/test/routes/root.test.ts
@@ -7,5 +7,5 @@ test('default root route', async (t) => {
   const res = await app.inject({
     url: '/'
   })
-  t.deepEqual(JSON.parse(res.payload), { root: true })
+  t.same(JSON.parse(res.payload), { root: true })
 })

--- a/templates/app/test/helper.js
+++ b/templates/app/test/helper.js
@@ -23,7 +23,7 @@ function build (t) {
   app.register(fp(App), config())
 
   // tear down our app after we are done
-  t.tearDown(app.close.bind(app))
+  t.teardown(app.close.bind(app))
 
   return app
 }

--- a/templates/app/test/routes/root.test.js
+++ b/templates/app/test/routes/root.test.js
@@ -9,7 +9,7 @@ test('default root route', async (t) => {
   const res = await app.inject({
     url: '/'
   })
-  t.deepEqual(JSON.parse(res.payload), { root: true })
+  t.same(JSON.parse(res.payload), { root: true })
 })
 
 // inject callback style:
@@ -22,6 +22,6 @@ test('default root route', async (t) => {
 //     url: '/'
 //   }, (err, res) => {
 //     t.error(err)
-//     t.deepEqual(JSON.parse(res.payload), { root: true })
+//     t.same(JSON.parse(res.payload), { root: true })
 //   })
 // })

--- a/templates/plugin/test/index.test.js
+++ b/templates/plugin/test/index.test.js
@@ -9,5 +9,5 @@ test('should register the correct decorator', async t => {
 
   await app.ready()
 
-  t.deepEqual(app.exampleDecorator(), 'decorated')
+  t.same(app.exampleDecorator(), 'decorated')
 })

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -27,7 +27,7 @@ test('should parse args correctly', t => {
   ]
   const parsedArgs = parseArgs(argv)
 
-  t.strictDeepEqual(parsedArgs, {
+  t.strictSame(parsedArgs, {
     _: ['app.js'],
     '--': [],
     prettyLogs: true,
@@ -77,7 +77,7 @@ test('should parse args with = assignment correctly', t => {
   ]
   const parsedArgs = parseArgs(argv)
 
-  t.strictDeepEqual(parsedArgs, {
+  t.strictSame(parsedArgs, {
     _: ['app.js'],
     '--': [],
     prettyLogs: true,
@@ -144,7 +144,7 @@ test('should parse env vars correctly', t => {
 
   const parsedArgs = parseArgs([])
 
-  t.strictDeepEqual(parsedArgs, {
+  t.strictSame(parsedArgs, {
     _: [],
     '--': [],
     prettyLogs: true,
@@ -178,18 +178,18 @@ test('should respect default values', t => {
 
   const parsedArgs = parseArgs(argv)
 
-  t.is(parsedArgs._[0], 'app.js')
-  t.is(parsedArgs.options, false)
-  t.is(parsedArgs.prettyLogs, false)
-  t.is(parsedArgs.watch, false)
-  t.is(parsedArgs.ignoreWatch, 'node_modules build dist .git bower_components logs .swp .nyc_output')
-  t.is(parsedArgs.verboseWatch, false)
-  t.is(parsedArgs.logLevel, 'fatal')
-  t.is(parsedArgs.pluginTimeout, 10000)
-  t.is(parsedArgs.debug, false)
-  t.is(parsedArgs.debugPort, 9320)
-  t.is(parsedArgs.loggingModule, undefined)
-  t.is(parsedArgs.require, undefined)
+  t.equal(parsedArgs._[0], 'app.js')
+  t.equal(parsedArgs.options, false)
+  t.equal(parsedArgs.prettyLogs, false)
+  t.equal(parsedArgs.watch, false)
+  t.equal(parsedArgs.ignoreWatch, 'node_modules build dist .git bower_components logs .swp .nyc_output')
+  t.equal(parsedArgs.verboseWatch, false)
+  t.equal(parsedArgs.logLevel, 'fatal')
+  t.equal(parsedArgs.pluginTimeout, 10000)
+  t.equal(parsedArgs.debug, false)
+  t.equal(parsedArgs.debugPort, 9320)
+  t.equal(parsedArgs.loggingModule, undefined)
+  t.equal(parsedArgs.require, undefined)
 })
 
 test('should parse custom plugin options', t => {
@@ -220,7 +220,7 @@ test('should parse custom plugin options', t => {
   ]
   const parsedArgs = parseArgs(argv)
 
-  t.strictDeepEqual(parsedArgs, {
+  t.strictSame(parsedArgs, {
     _: ['app.js'],
     '--': [
       '-abc',

--- a/test/eject-ts.test.js
+++ b/test/eject-ts.test.js
@@ -76,7 +76,7 @@ function define (t) {
           try {
             const data = readFileSync(file)
             file = file.replace(workdir, '')
-            t.deepEqual(
+            t.same(
               data.toString().replace(/\r\n/g, '\n'),
               expected[file],
               file + ' matching'

--- a/test/eject.test.js
+++ b/test/eject.test.js
@@ -77,7 +77,7 @@ function define (t) {
           try {
             const data = readFileSync(file)
             file = file.replace(workdir, '')
-            t.deepEqual(data.toString().replace(/\r\n/g, '\n'), expected[file], file + ' matching')
+            t.same(data.toString().replace(/\r\n/g, '\n'), expected[file], file + ' matching')
           } catch (err) {
             reject(err)
           }

--- a/test/generate-plugin.test.js
+++ b/test/generate-plugin.test.js
@@ -66,40 +66,40 @@ function define (t) {
   test('errors if directory exists', (t) => {
     t.plan(2)
     exec('node generate-plugin.js ./test/workdir', (err, stdout) => {
-      t.is('directory ./test/workdir already exists', strip(stdout.toString().trim()))
-      t.is(1, err.code)
+      t.equal('directory ./test/workdir already exists', strip(stdout.toString().trim()))
+      t.equal(1, err.code)
     })
   })
 
   test('errors if generate doesn\'t have <folder> arguments', (t) => {
     t.plan(2)
     exec('node generate-plugin.js', (err, stdout) => {
-      t.is('must specify a directory to \'fastify generate\'', strip(stdout.toString().trim()))
-      t.is(1, err.code)
+      t.equal('must specify a directory to \'fastify generate\'', strip(stdout.toString().trim()))
+      t.equal(1, err.code)
     })
   })
 
   test('errors if package.json exists when use generate .', (t) => {
     t.plan(2)
     exec('node generate-plugin.js .', (err, stdout) => {
-      t.is('a package.json file already exists in target directory', strip(stdout.toString().trim()))
-      t.is(1, err.code)
+      t.equal('a package.json file already exists in target directory', strip(stdout.toString().trim()))
+      t.equal(1, err.code)
     })
   })
 
   test('errors if package.json exists when use generate ./', (t) => {
     t.plan(2)
     exec('node generate-plugin.js ./', (err, stdout) => {
-      t.is('a package.json file already exists in target directory', strip(stdout.toString().trim()))
-      t.is(1, err.code)
+      t.equal('a package.json file already exists in target directory', strip(stdout.toString().trim()))
+      t.equal(1, err.code)
     })
   })
 
   test('errors if folder exists', (t) => {
     t.plan(2)
     exec('node generate-plugin.js test', (err, stdout) => {
-      t.is('directory test already exists', strip(stdout.toString().trim()))
-      t.is(1, err.code)
+      t.equal('directory test already exists', strip(stdout.toString().trim()))
+      t.equal(1, err.code)
     })
   })
 
@@ -140,7 +140,7 @@ function define (t) {
         t.equal(pkg.devDependencies.tap, cliPkg.devDependencies.tap)
         t.equal(pkg.devDependencies.tsd, cliPkg.devDependencies.tsd)
         t.equal(pkg.devDependencies.typescript, cliPkg.devDependencies.typescript)
-        t.deepEqual(pkg.tsd, pluginTemplate.tsd)
+        t.same(pkg.tsd, pluginTemplate.tsd)
 
         const testGlob = pkg.scripts.unit.split(' ')[1]
         t.equal(minimatch.match(['test/more/test/here/ok.test.js'], testGlob).length, 1)
@@ -161,7 +161,7 @@ function define (t) {
           try {
             const data = readFileSync(file)
             file = file.replace(workdir, '')
-            t.deepEqual(data.toString().replace(/\r\n/g, '\n'), expected[file], file + ' matching')
+            t.same(data.toString().replace(/\r\n/g, '\n'), expected[file], file + ' matching')
           } catch (err) {
             reject(err)
           }

--- a/test/generate-typescript.test.js
+++ b/test/generate-typescript.test.js
@@ -66,40 +66,40 @@ function define (t) {
   test('errors if directory exists', (t) => {
     t.plan(2)
     exec('node generate.js --lang=ts ./test/workdir', (err, stdout) => {
-      t.is('directory ./test/workdir already exists', strip(stdout.toString().trim()))
-      t.is(1, err.code)
+      t.equal('directory ./test/workdir already exists', strip(stdout.toString().trim()))
+      t.equal(1, err.code)
     })
   })
 
   test('errors if generate doesn\'t have <folder> arguments', (t) => {
     t.plan(2)
     exec('node generate.js --lang=ts', (err, stdout) => {
-      t.is('must specify a directory to \'fastify generate\'', strip(stdout.toString().trim()))
-      t.is(1, err.code)
+      t.equal('must specify a directory to \'fastify generate\'', strip(stdout.toString().trim()))
+      t.equal(1, err.code)
     })
   })
 
   test('errors if package.json exists when use generate .', (t) => {
     t.plan(2)
     exec('node generate.js --lang=ts .', (err, stdout) => {
-      t.is('a package.json file already exists in target directory', strip(stdout.toString().trim()))
-      t.is(1, err.code)
+      t.equal('a package.json file already exists in target directory', strip(stdout.toString().trim()))
+      t.equal(1, err.code)
     })
   })
 
   test('errors if package.json exists when use generate ./', (t) => {
     t.plan(2)
     exec('node generate.js --lang=ts ./', (err, stdout) => {
-      t.is('a package.json file already exists in target directory', strip(stdout.toString().trim()))
-      t.is(1, err.code)
+      t.equal('a package.json file already exists in target directory', strip(stdout.toString().trim()))
+      t.equal(1, err.code)
     })
   })
 
   test('errors if folder exists', (t) => {
     t.plan(2)
     exec('node generate.js --lang=ts test', (err, stdout) => {
-      t.is('directory test already exists', strip(stdout.toString().trim()))
-      t.is(1, err.code)
+      t.equal('directory test already exists', strip(stdout.toString().trim()))
+      t.equal(1, err.code)
     })
   })
 
@@ -160,7 +160,7 @@ function define (t) {
 
       t.equal(tsConfig.extends, 'fastify-tsconfig')
       t.equal(tsConfig.compilerOptions.outDir, 'dist')
-      t.deepEqual(tsConfig.include, ['src/**/*.ts'])
+      t.same(tsConfig.include, ['src/**/*.ts'])
     })
   }
 
@@ -176,7 +176,7 @@ function define (t) {
           try {
             const data = readFileSync(file)
             file = file.replace(workdir, '')
-            t.deepEqual(data.toString().replace(/\r\n/g, '\n'), expected[file], file + ' matching')
+            t.same(data.toString().replace(/\r\n/g, '\n'), expected[file], file + ' matching')
           } catch (err) {
             reject(err)
           }

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -70,40 +70,40 @@ function define (t) {
   test('errors if directory exists', (t) => {
     t.plan(2)
     exec('node generate.js ./test/workdir', (err, stdout) => {
-      t.is('directory ./test/workdir already exists', strip(stdout.toString().trim()))
-      t.is(1, err.code)
+      t.equal('directory ./test/workdir already exists', strip(stdout.toString().trim()))
+      t.equal(1, err.code)
     })
   })
 
   test('errors if generate doesn\'t have <folder> arguments', (t) => {
     t.plan(2)
     exec('node generate.js', (err, stdout) => {
-      t.is('must specify a directory to \'fastify generate\'', strip(stdout.toString().trim()))
-      t.is(1, err.code)
+      t.equal('must specify a directory to \'fastify generate\'', strip(stdout.toString().trim()))
+      t.equal(1, err.code)
     })
   })
 
   test('errors if package.json exists when use generate . and integrate flag is not set', (t) => {
     t.plan(2)
     exec('node generate.js .', (err, stdout) => {
-      t.is('a package.json file already exists in target directory', strip(stdout.toString().trim()))
-      t.is(1, err.code)
+      t.equal('a package.json file already exists in target directory', strip(stdout.toString().trim()))
+      t.equal(1, err.code)
     })
   })
 
   test('errors if package.json exists when use generate ./ and integrate flag is not set', (t) => {
     t.plan(2)
     exec('node generate.js ./', (err, stdout) => {
-      t.is('a package.json file already exists in target directory', strip(stdout.toString().trim()))
-      t.is(1, err.code)
+      t.equal('a package.json file already exists in target directory', strip(stdout.toString().trim()))
+      t.equal(1, err.code)
     })
   })
 
   test('errors if folder exists', (t) => {
     t.plan(2)
     exec('node generate.js test', (err, stdout) => {
-      t.is('directory test already exists', strip(stdout.toString().trim()))
-      t.is(1, err.code)
+      t.equal('directory test already exists', strip(stdout.toString().trim()))
+      t.equal(1, err.code)
     })
   })
 
@@ -174,7 +174,7 @@ function define (t) {
           try {
             const data = readFileSync(file)
             file = file.replace(workdir, '')
-            t.deepEqual(data.toString().replace(/\r\n/g, '\n'), expected[file], file + ' matching')
+            t.same(data.toString().replace(/\r\n/g, '\n'), expected[file], file + ' matching')
           } catch (err) {
             reject(err)
           }

--- a/test/graceful-shutdown.test.js
+++ b/test/graceful-shutdown.test.js
@@ -35,11 +35,11 @@ t.afterEach(async (done, t) => {
 test('should add and remove SIGINT listener as expected ', async t => {
   t.plan(2)
 
-  t.strictEqual(process.listenerCount('SIGINT'), signalCounter + 1)
+  t.equal(process.listenerCount('SIGINT'), signalCounter + 1)
 
   await fastify.close()
 
-  t.strictEqual(process.listenerCount('SIGINT'), signalCounter)
+  t.equal(process.listenerCount('SIGINT'), signalCounter)
 
   t.end()
 })

--- a/test/print-routes.test.js
+++ b/test/print-routes.test.js
@@ -39,7 +39,7 @@ test('should warn on file not found', t => {
   t.plan(1)
 
   const oldStop = printRoutes.stop
-  t.tearDown(() => { printRoutes.stop = oldStop })
+  t.teardown(() => { printRoutes.stop = oldStop })
   printRoutes.stop = function (message) {
     t.ok(/.*not-found.js doesn't exist within/.test(message), message)
   }
@@ -52,7 +52,7 @@ test('should throw on package not found', t => {
   t.plan(1)
 
   const oldStop = printRoutes.stop
-  t.tearDown(() => { printRoutes.stop = oldStop })
+  t.teardown(() => { printRoutes.stop = oldStop })
   printRoutes.stop = function (err) {
     t.ok(/Cannot find module 'unknown-package'/.test(err.message), err.message)
   }
@@ -65,7 +65,7 @@ test('should throw on parsing error', t => {
   t.plan(1)
 
   const oldStop = printRoutes.stop
-  t.tearDown(() => { printRoutes.stop = oldStop })
+  t.teardown(() => { printRoutes.stop = oldStop })
   printRoutes.stop = function (err) {
     t.equal(err.constructor, SyntaxError)
   }
@@ -78,7 +78,7 @@ test('should exit without error on help', t => {
   const exit = process.exit
   process.exit = sinon.spy()
 
-  t.tearDown(() => {
+  t.teardown(() => {
     process.exit = exit
   })
 

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -55,9 +55,9 @@ test('should start the server', async t => {
     method: 'GET',
     url: `http://localhost:${fastify.server.address().port}`
   })
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-length'], '' + body.length)
-  t.deepEqual(JSON.parse(body), { hello: 'world' })
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+  t.same(JSON.parse(body), { hello: 'world' })
 
   await fastify.close()
   t.pass('server closed')
@@ -73,9 +73,9 @@ test('should start the server with a typescript compiled module', async t => {
     method: 'GET',
     url: `http://localhost:${fastify.server.address().port}`
   })
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-length'], '' + body.length)
-  t.deepEqual(JSON.parse(body), { hello: 'world' })
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+  t.same(JSON.parse(body), { hello: 'world' })
 
   await fastify.close()
   t.pass('server closed')
@@ -91,9 +91,9 @@ test('should start the server with pretty output', async t => {
     method: 'GET',
     url: `http://localhost:${fastify.server.address().port}`
   })
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-length'], '' + body.length)
-  t.deepEqual(JSON.parse(body), { hello: 'world' })
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+  t.same(JSON.parse(body), { hello: 'world' })
 
   await fastify.close()
   t.pass('server closed')
@@ -132,9 +132,9 @@ test('should start fastify with custom plugin options', async t => {
     url: `http://localhost:${fastify.server.address().port}`
   })
 
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-length'], '' + body.length)
-  t.deepEqual(JSON.parse(body), {
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+  t.same(JSON.parse(body), {
     a: true,
     b: true,
     c: true,
@@ -177,9 +177,9 @@ test('should start fastify with custom plugin options with a typescript compiled
     url: `http://localhost:${fastify.server.address().port}`
   })
 
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-length'], '' + body.length)
-  t.deepEqual(JSON.parse(body), {
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+  t.same(JSON.parse(body), {
     a: true,
     b: true,
     c: true,
@@ -201,9 +201,9 @@ test('should start the server at the given prefix', async t => {
     url: `http://localhost:${fastify.server.address().port}/api/hello`
   })
 
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-length'], '' + body.length)
-  t.deepEqual(JSON.parse(body), { hello: 'world' })
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+  t.same(JSON.parse(body), { hello: 'world' })
 
   await fastify.close()
   t.pass('server closed')
@@ -213,7 +213,7 @@ test('should start fastify at given socket path', { skip: process.platform === '
   t.plan(1)
 
   const sockFile = path.resolve('test.sock')
-  t.tearDown(() => {
+  t.teardown(() => {
     try {
       fs.unlinkSync(sockFile)
     } catch (e) { }
@@ -232,13 +232,13 @@ test('should start fastify at given socket path', { skip: process.platform === '
       path: '/',
       socketPath: sockFile
     }, function (response) {
-      t.deepEqual(response.statusCode, 200)
+      t.same(response.statusCode, 200)
       return resolve()
     })
     request.end()
   })
 
-  t.tearDown(fastify.close.bind(fastify))
+  t.teardown(fastify.close.bind(fastify))
 })
 
 test('should error with a good timeout value', async t => {
@@ -264,7 +264,7 @@ test('should warn on file not found', t => {
   t.plan(1)
 
   const oldStop = start.stop
-  t.tearDown(() => { start.stop = oldStop })
+  t.teardown(() => { start.stop = oldStop })
   start.stop = function (message) {
     t.ok(/.*not-found.js doesn't exist within/.test(message), message)
   }
@@ -277,7 +277,7 @@ test('should throw on package not found', t => {
   t.plan(1)
 
   const oldStop = start.stop
-  t.tearDown(() => { start.stop = oldStop })
+  t.teardown(() => { start.stop = oldStop })
   start.stop = function (err) {
     t.ok(/Cannot find module 'unknown-package'/.test(err.message), err.message)
   }
@@ -290,7 +290,7 @@ test('should throw on parsing error', t => {
   t.plan(1)
 
   const oldStop = start.stop
-  t.tearDown(() => { start.stop = oldStop })
+  t.teardown(() => { start.stop = oldStop })
   start.stop = function (err) {
     t.equal(err.constructor, SyntaxError)
   }
@@ -315,9 +315,9 @@ test('should start the server with an async/await plugin', async t => {
     url: `http://localhost:${fastify.server.address().port}`
   })
 
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-length'], '' + body.length)
-  t.deepEqual(JSON.parse(body), { hello: 'world' })
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+  t.same(JSON.parse(body), { hello: 'world' })
 
   await fastify.close()
   t.pass('server closed')
@@ -327,7 +327,7 @@ test('should exit without error on help', t => {
   const exit = process.exit
   process.exit = sinon.spy()
 
-  t.tearDown(() => {
+  t.teardown(() => {
     process.exit = exit
   })
 
@@ -344,7 +344,7 @@ test('should throw the right error on require file', t => {
   t.plan(1)
 
   const oldStop = start.stop
-  t.tearDown(() => { start.stop = oldStop })
+  t.teardown(() => { start.stop = oldStop })
   start.stop = function (err) {
     t.ok(/undefinedVariable is not defined/.test(err.message), err.message)
   }
@@ -370,7 +370,7 @@ test('should respond 413 - Payload too large', async t => {
     json: true
   })
 
-  t.strictEqual(responseFail.statusCode, 413)
+  t.equal(responseFail.statusCode, 413)
 
   const { response: responseOk } = await sget({
     method: 'POST',
@@ -378,7 +378,7 @@ test('should respond 413 - Payload too large', async t => {
     body: bodySmaller,
     json: true
   })
-  t.strictEqual(responseOk.statusCode, 200)
+  t.equal(responseOk.statusCode, 200)
 
   await fastify.close()
   t.pass('server closed')
@@ -395,9 +395,9 @@ test('should start the server (using env var)', async t => {
     method: 'GET',
     url: `http://localhost:${process.env.FASTIFY_PORT}`
   })
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-length'], '' + body.length)
-  t.deepEqual(JSON.parse(body), { hello: 'world' })
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+  t.same(JSON.parse(body), { hello: 'world' })
 
   delete process.env.FASTIFY_PORT
 
@@ -416,9 +416,9 @@ test('should start the server (using PORT-env var)', async t => {
     method: 'GET',
     url: `http://localhost:${process.env.PORT}`
   })
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-length'], '' + body.length)
-  t.deepEqual(JSON.parse(body), { hello: 'world' })
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+  t.same(JSON.parse(body), { hello: 'world' })
 
   delete process.env.PORT
 
@@ -439,9 +439,9 @@ test('should start the server (using FASTIFY_PORT-env preceding PORT-env var)', 
     url: `http://localhost:${process.env.FASTIFY_PORT}`
   })
 
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-length'], '' + body.length)
-  t.deepEqual(JSON.parse(body), { hello: 'world' })
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+  t.same(JSON.parse(body), { hello: 'world' })
 
   delete process.env.FASTIFY_PORT
   delete process.env.PORT
@@ -463,9 +463,9 @@ test('should start the server (using -p preceding FASTIFY_PORT-env var)', async 
     url: `http://localhost:${port}`
   })
 
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-length'], '' + body.length)
-  t.deepEqual(JSON.parse(body), { hello: 'world' })
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+  t.same(JSON.parse(body), { hello: 'world' })
 
   delete process.env.FASTIFY_PORT
 
@@ -485,9 +485,9 @@ test('should start the server at the given prefix (using env var)', async t => {
     method: 'GET',
     url: `http://localhost:${process.env.FASTIFY_PORT}/api/hello`
   })
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-length'], '' + body.length)
-  t.deepEqual(JSON.parse(body), { hello: 'world' })
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+  t.same(JSON.parse(body), { hello: 'world' })
 
   delete process.env.FASTIFY_PORT
   delete process.env.FASTIFY_PREFIX
@@ -509,7 +509,7 @@ test('should start the server at the given prefix (using env var read from doten
   })
   const argv = ['./examples/plugin.js']
   const fastify = await start.start(argv)
-  t.strictEqual(fastify.server.address().port, 8080)
+  t.equal(fastify.server.address().port, 8080)
   delete process.env.FASTIFY_PORT
 
   await fastify.close()
@@ -528,7 +528,7 @@ test('should start the server listening on 0.0.0.0 when running in docker', asyn
   const argv = ['-p', getPort(), './examples/plugin.js']
   const fastify = await start.start(argv)
 
-  t.strictEqual(fastify.server.address().address, '0.0.0.0')
+  t.equal(fastify.server.address().address, '0.0.0.0')
 
   await fastify.close()
   t.pass('server closed')
@@ -542,7 +542,7 @@ test('should start the server with watch options that the child process restart 
   const argv = ['-p', '4042', '-w', './examples/plugin.js']
   const fastifyEmitter = await start.start(argv)
 
-  t.tearDown(() => {
+  t.teardown(() => {
     if (fs.existsSync(tmpjs)) {
       fs.unlinkSync(tmpjs)
     }
@@ -583,7 +583,7 @@ test('should start the server with watch and verbose-watch options that the chil
   const argv = ['-p', '4042', '-w', '--verbose-watch', './examples/plugin.js']
   const fastifyEmitter = await start.start(argv)
 
-  t.tearDown(() => {
+  t.teardown(() => {
     if (fs.existsSync(tmpjs)) {
       fs.unlinkSync(tmpjs)
     }
@@ -620,7 +620,7 @@ test('should reload the env on restart when watching', async (t) => {
   const argv = ['-p', port, '-w', path.join(testdir, 'plugin.js')]
   const fastifyEmitter = await requireUncached('../start').start(argv)
 
-  t.tearDown(() => {
+  t.teardown(() => {
     fastifyEmitter.emit('close')
     process.chdir(cwd)
   })
@@ -632,8 +632,8 @@ test('should reload the env on restart when watching', async (t) => {
     url: `http://localhost:${port}`
   })
 
-  t.strictEqual(r1.response.statusCode, 200)
-  t.deepEqual(JSON.parse(r1.body), { hello: 'world' })
+  t.equal(r1.response.statusCode, 200)
+  t.same(JSON.parse(r1.body), { hello: 'world' })
 
   await writeFile(path.join(testdir, '.env'), 'GREETING=planet')
 
@@ -644,8 +644,8 @@ test('should reload the env on restart when watching', async (t) => {
     url: `http://localhost:${port}`
   })
 
-  t.strictEqual(r2.response.statusCode, 200)
-  t.deepEqual(JSON.parse(r2.body), { hello: 'planet' })
+  t.equal(r2.response.statusCode, 200)
+  t.same(JSON.parse(r2.body), { hello: 'planet' })
 })
 
 test('should read env variables from .env file', async (t) => {
@@ -660,20 +660,20 @@ test('should read env variables from .env file', async (t) => {
 
   process.chdir(testdir)
 
-  t.tearDown(() => {
+  t.teardown(() => {
     process.chdir(cwd)
   })
 
   const fastify = await requireUncached('../start').start([path.join(testdir, 'plugin.js')])
-  t.strictEqual(fastify.server.address().port, +port)
+  t.equal(fastify.server.address().port, +port)
 
   const res = await sget({
     method: 'GET',
     url: `http://localhost:${port}`
   })
 
-  t.strictEqual(res.response.statusCode, 200)
-  t.deepEqual(JSON.parse(res.body), { hello: 'world' })
+  t.equal(res.response.statusCode, 200)
+  t.same(JSON.parse(res.body), { hello: 'world' })
 
   await fastify.close()
 })
@@ -684,7 +684,7 @@ test('crash on unhandled rejection', t => {
   const argv = ['-p', getPort(), './test/data/rejection.js']
   const child = fork(path.join(__dirname, '..', 'start.js'), argv, { silent: true })
   child.on('close', function (code) {
-    t.strictEqual(code, 1)
+    t.equal(code, 1)
   })
 })
 
@@ -694,7 +694,7 @@ test('should start the server with inspect options and the defalut port is 9320'
   const start = proxyquire('../start', {
     inspector: {
       open (p) {
-        t.strictEqual(p, 9320)
+        t.equal(p, 9320)
         t.pass('inspect open called')
       }
     }
@@ -713,7 +713,7 @@ test('should start the server with inspect options and use the exactly port', as
   const start = proxyquire('../start', {
     inspector: {
       open (p) {
-        t.strictEqual(p, Number(port))
+        t.equal(p, Number(port))
         t.pass('inspect open called')
       }
     }
@@ -779,7 +779,7 @@ test('preloading custom module that is not found should throw', async t => {
   t.plan(2)
 
   const oldStop = start.stop
-  t.tearDown(() => { start.stop = oldStop })
+  t.teardown(() => { start.stop = oldStop })
   start.stop = function (err) {
     t.ok(/Cannot find module/.test(err.message), err.message)
   }
@@ -802,9 +802,9 @@ test('preloading custom module should be done before starting server', async t =
     url: `http://localhost:${fastify.server.address().port}`
   })
 
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-length'], '' + body.length)
-  t.deepEqual(JSON.parse(body), { hasPreloaded: true })
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+  t.same(JSON.parse(body), { hasPreloaded: true })
 
   await fastify.close()
   t.pass('server closed')
@@ -843,7 +843,7 @@ test('should throw on logger configuration module not found', async t => {
   t.plan(2)
 
   const oldStop = start.stop
-  t.tearDown(() => { start.stop = oldStop })
+  t.teardown(() => { start.stop = oldStop })
   start.stop = function (err) {
     t.ok(/Cannot find module/.test(err.message), err.message)
   }
@@ -859,7 +859,7 @@ test('should throw on async plugin with one argument', async t => {
   t.plan(1)
 
   const oldStop = start.stop
-  t.tearDown(() => { start.stop = oldStop })
+  t.teardown(() => { start.stop = oldStop })
   start.stop = function (err) {
     t.ok(/Async\/Await plugin function should contain 2 arguments./.test(err.message), err.message)
   }
@@ -887,9 +887,9 @@ test('should start fastify with custom plugin options with a ESM typescript comp
     url: `http://localhost:${fastify.server.address().port}`
   })
 
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-length'], '' + body.length)
-  t.deepEqual(JSON.parse(body), {
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+  t.same(JSON.parse(body), {
     a: true,
     b: true,
     c: true,
@@ -905,7 +905,7 @@ test('should throw an error when loading ESM typescript compiled plugin and ESM 
   t.plan(1)
 
   const oldStop = start.stop
-  t.tearDown(() => { start.stop = oldStop })
+  t.teardown(() => { start.stop = oldStop })
   start.stop = function (err) {
     t.ok(/Your version of node does not support ES modules./.test(err.message), err.message)
   }
@@ -934,9 +934,9 @@ test('should start fastify with custom plugin options with a ESM plugin with pac
     url: `http://localhost:${fastify.server.address().port}`
   })
 
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-length'], '' + body.length)
-  t.deepEqual(JSON.parse(body), {
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+  t.same(JSON.parse(body), {
     a: true,
     b: true,
     c: true,
@@ -967,9 +967,9 @@ test('should start fastify with custom plugin options with a CJS plugin with pac
     url: `http://localhost:${fastify.server.address().port}`
   })
 
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-length'], '' + body.length)
-  t.deepEqual(JSON.parse(body), {
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+  t.same(JSON.parse(body), {
     a: true,
     b: true,
     c: true,

--- a/test/templates/app-ts.test.ts
+++ b/test/templates/app-ts.test.ts
@@ -26,9 +26,9 @@ test('should print routes for TS app', async t => {
         method: 'GET',
         url: `http://localhost:${(fastifyApp.server.address() as AddressInfo).port}`
     })
-    t.strictEqual(response.statusCode, 200)
-    t.strictEqual(response.headers['content-length'], '' + body.length)
-    t.deepEqual(JSON.parse(body), { root: true })
+    t.equal(response.statusCode, 200)
+    t.equal(response.headers['content-length'], '' + body.length)
+    t.same(JSON.parse(body), { root: true })
 
     await fastifyApp.close();
     t.pass('server closed')
@@ -46,9 +46,9 @@ test('should print routes for default TS app', async t => {
         method: 'GET',
         url: `http://localhost:${(fastifyApp.server.address() as AddressInfo).port}`
     })
-    t.strictEqual(response.statusCode, 200)
-    t.strictEqual(response.headers['content-length'], '' + body.length)
-    t.deepEqual(JSON.parse(body), { root: true })
+    t.equal(response.statusCode, 200)
+    t.equal(response.headers['content-length'], '' + body.length)
+    t.same(JSON.parse(body), { root: true })
 
     await fastifyApp.close();
     t.pass('server closed')

--- a/test/watch.test.js
+++ b/test/watch.test.js
@@ -11,5 +11,5 @@ test('should equal expect RegExp', t => {
   const expectRegExp = /(node_modules|build|dist|\.git|bower_components|logs)/
   const regExp = arrayToRegExp(['node_modules', 'build', 'dist', '.git', 'bower_components', 'logs'])
 
-  t.deepEqual(regExp, expectRegExp)
+  t.same(regExp, expectRegExp)
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


* Tries to resolve all tap assertion deprecations in fastify-cli repo + templates
* Made a quick test with `node ./generate.js --lang=ts`  and `node ./generate.js`
* Path the way to a Tap upgrade maybe
