### PR TITLE
fix: only list files on the left-side navbar

### DIFF
--- a/docs.js
+++ b/docs.js
@@ -11,12 +11,13 @@ function renderDocs () {
   if (!docsBase) return console.error('Something went wrong finding docs... please report a bug! https://github.com/fastify/fastify-cli')
 
   const fileNames = fs.readdirSync(docsBase)
-  const docNames = fileNames.map(fileName => fileName.replace(/-/g, ' ').replace(/\.md$/, ''))
+  let docNames = []
 
   const fileContents = []
   for (const fileName of fileNames) {
     const fullFilePath = path.join(docsBase, fileName)
     if (fs.lstatSync(fullFilePath).isFile()) {
+      docNames.push(fileName.replace(/-/g, ' ').replace(/\.md$/, ''))
       fileContents.push((fs.readFileSync(fullFilePath)).toString('utf8'))
     }
   }

--- a/docs.js
+++ b/docs.js
@@ -11,7 +11,7 @@ function renderDocs () {
   if (!docsBase) return console.error('Something went wrong finding docs... please report a bug! https://github.com/fastify/fastify-cli')
 
   const fileNames = fs.readdirSync(docsBase)
-  let docNames = []
+  const docNames = []
 
   const fileContents = []
   for (const fileName of fileNames) {


### PR DESCRIPTION
## Expected

I can navigate the left-bar files to read documentation, without triggering any errors

## Actual

When I run `fastify docs` for my project, it lists an entry `resources` at the end of the list which is apparently a directory:
![image](https://user-images.githubusercontent.com/316371/122555783-645af180-d043-11eb-801c-8c7dc9a7b1b2.png)

Clicking on this `resources` entry triggers an exception:
![image](https://user-images.githubusercontent.com/316371/122555829-7472d100-d043-11eb-9508-cba3dd9710b0.png)


## Proposed change

The list of files is generated as part of the logic that checks whether an entry is a filename to retrieve its content.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
