### PR TITLE
Add default readme for generated project

### DIFF
--- a/templates/app-ts/README.md
+++ b/templates/app-ts/README.md
@@ -1,0 +1,24 @@
+# Getting Started with Fastify-CLI
+
+###### This project was bootstrapped with [Fastify-CLI](https://github.com/fastify/fastify-cli).
+
+## Available Scripts
+
+###### In the project directory, you can run:
+
+### `npm run dev`
+
+###### To start the app in dev mode.\
+###### Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+
+### `npm start`
+
+###### For production mode
+
+### `npm run test`
+
+###### Run the test cases.
+
+## Learn More
+
+###### To learn Fastify, check out the [Fastify documentation](https://www.fastify.io/docs/latest/).

--- a/templates/app-ts/README.md
+++ b/templates/app-ts/README.md
@@ -1,24 +1,23 @@
-# Getting Started with Fastify-CLI
-
-###### This project was bootstrapped with [Fastify-CLI](https://github.com/fastify/fastify-cli).
+# Getting Started with [Fastify-CLI](https://www.npmjs.com/package/fastify-cli)
+This project was bootstrapped with Fastify-CLI.
 
 ## Available Scripts
 
-###### In the project directory, you can run:
+In the project directory, you can run:
 
 ### `npm run dev`
 
-###### To start the app in dev mode.\
-###### Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+To start the app in dev mode.\
+Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
 ### `npm start`
 
-###### For production mode
+For production mode
 
 ### `npm run test`
 
-###### Run the test cases.
+Run the test cases.
 
 ## Learn More
 
-###### To learn Fastify, check out the [Fastify documentation](https://www.fastify.io/docs/latest/).
+To learn Fastify, check out the [Fastify documentation](https://www.fastify.io/docs/latest/).

--- a/templates/app/README.md
+++ b/templates/app/README.md
@@ -1,0 +1,24 @@
+# Getting Started with Fastify-CLI
+
+###### This project was bootstrapped with [Fastify-CLI](https://github.com/fastify/fastify-cli).
+
+## Available Scripts
+
+###### In the project directory, you can run:
+
+### `npm run dev`
+
+###### To start the app in dev mode.\
+###### Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+
+### `npm start`
+
+###### For production mode
+
+### `npm run test`
+
+###### Run the test cases.
+
+## Learn More
+
+###### To learn Fastify, check out the [Fastify documentation](https://www.fastify.io/docs/latest/).

--- a/templates/app/README.md
+++ b/templates/app/README.md
@@ -1,24 +1,23 @@
-# Getting Started with Fastify-CLI
-
-###### This project was bootstrapped with [Fastify-CLI](https://github.com/fastify/fastify-cli).
+# Getting Started with Fastify-CLI [Fastify-CLI](https://www.npmjs.com/package/fastify-cli)
+This project was bootstrapped with Fastify-CLI.
 
 ## Available Scripts
 
-###### In the project directory, you can run:
+In the project directory, you can run:
 
 ### `npm run dev`
 
-###### To start the app in dev mode.\
-###### Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+To start the app in dev mode.\
+Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
 ### `npm start`
 
-###### For production mode
+For production mode
 
 ### `npm run test`
 
-###### Run the test cases.
+Run the test cases.
 
 ## Learn More
 
-###### To learn Fastify, check out the [Fastify documentation](https://www.fastify.io/docs/latest/).
+To learn Fastify, check out the [Fastify documentation](https://www.fastify.io/docs/latest/).

--- a/test/generate-typescript.test.js
+++ b/test/generate-typescript.test.js
@@ -121,7 +121,7 @@ function define (t) {
         t.equal(pkg.name, 'workdir')
         // we are not checking author because it depends on global npm configs
         t.equal(pkg.version, '1.0.0')
-        t.equal(pkg.description, '')
+        t.equal(pkg.description, 'This project was bootstrapped with Fastify-CLI.')
         // by default this will be ISC but since we have a MIT licensed pkg file in upper dir, npm will set the license to MIT in this case
         // so for local tests we need to accept MIT as well
         t.ok(pkg.license === 'ISC' || pkg.license === 'MIT')

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -138,7 +138,7 @@ function define (t) {
         t.equal(pkg.name, 'workdir')
         // we are not checking author because it depends on global npm configs
         t.equal(pkg.version, '1.0.0')
-        t.equal(pkg.description, '')
+        t.equal(pkg.description, 'This project was bootstrapped with Fastify-CLI.')
         // by default this will be ISC but since we have a MIT licensed pkg file in upper dir, npm will set the license to MIT in this case
         // so for local tests we need to accept MIT as well
         t.ok(pkg.license === 'ISC' || pkg.license === 'MIT')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
Closes #362 

This PR took me a whole day to debug. There is something wrong with tests, maybe with a specific npm package.
When adding a `README.md` template in `app` and `app-ts` like following
```
# Getting Started with Fastify-CLI

This project was bootstrapped with [Fastify-CLI](https://github.com/fastify/fastify-cli).

```

This results in the failure of test suitss. A workaround for this is to add content like the following:
```
# Getting Started with Fastify-CLI

###### This project was bootstrapped with [Fastify-CLI](https://github.com/fastify/fastify-cli).
```
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
