### PR TITLE
refactor(config): move ts-node flag

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -45,7 +45,7 @@ const typescriptTemplate = {
   dir: 'app-ts',
   main: 'app.ts',
   scripts: {
-    test: 'npm run build:ts && tsc -p test/tsconfig.test.json && cross-env TS_NODE_FILES=true tap --ts test/**/*.test.ts',
+    test: 'npm run build:ts && tsc -p test/tsconfig.test.json && tap --ts test/**/*.test.ts',
     start: 'npm run build:ts && fastify start -l info dist/app.js',
     'build:ts': 'tsc',
     dev: 'tsc && concurrently -k -p "[{name}]" -n "TypeScript,App" -c "yellow.bold,cyan.bold" "tsc -w" "fastify start --ignore-watch=.ts$ -w -l info -P dist/app.js"'
@@ -62,7 +62,6 @@ const typescriptTemplate = {
     '@types/tap': cliPkg.devDependencies['@types/tap'],
     'ts-node': cliPkg.devDependencies['ts-node'],
     concurrently: cliPkg.devDependencies.concurrently,
-    'cross-env': cliPkg.devDependencies['cross-env'],
     'fastify-tsconfig': cliPkg.devDependencies['fastify-tsconfig'],
     tap: cliPkg.devDependencies.tap,
     typescript: cliPkg.devDependencies.typescript

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "@types/node": "^16.0.0",
     "@types/tap": "^15.0.0",
     "concurrently": "^6.0.0",
-    "cross-env": "^7.0.3",
     "del-cli": "^3.0.1",
     "fastify-autoload": "^3.3.1",
     "fastify-plugin": "^3.0.0",

--- a/templates/app-ts/__taprc
+++ b/templates/app-ts/__taprc
@@ -1,3 +1,4 @@
 test-env: [
+  TS_NODE_FILES=true,
   TS_NODE_PROJECT=./test/tsconfig.test.json
 ]

--- a/test/generate-typescript.test.js
+++ b/test/generate-typescript.test.js
@@ -125,7 +125,7 @@ function define (t) {
         // by default this will be ISC but since we have a MIT licensed pkg file in upper dir, npm will set the license to MIT in this case
         // so for local tests we need to accept MIT as well
         t.ok(pkg.license === 'ISC' || pkg.license === 'MIT')
-        t.equal(pkg.scripts.test, 'npm run build:ts && tsc -p test/tsconfig.test.json && cross-env TS_NODE_FILES=true tap --ts test/**/*.test.ts')
+        t.equal(pkg.scripts.test, 'npm run build:ts && tsc -p test/tsconfig.test.json && tap --ts test/**/*.test.ts')
         t.equal(pkg.scripts.start, 'npm run build:ts && fastify start -l info dist/app.js')
         t.equal(pkg.scripts['build:ts'], 'tsc')
         t.equal(pkg.scripts.dev, 'tsc && concurrently -k -p "[{name}]" -n "TypeScript,App" -c "yellow.bold,cyan.bold" "tsc -w" "fastify start --ignore-watch=.ts$ -w -l info -P dist/app.js"')
@@ -140,7 +140,7 @@ function define (t) {
         t.equal(pkg.devDependencies.tap, cliPkg.devDependencies.tap)
         t.equal(pkg.devDependencies.typescript, cliPkg.devDependencies.typescript)
 
-        const testGlob = pkg.scripts.test.split(' ')[12]
+        const testGlob = pkg.scripts.test.split(' ')[10]
 
         t.equal(minimatch.match(['test/routes/plugins/more/test/here/ok.test.ts'], testGlob).length, 1)
         resolve()


### PR DESCRIPTION
Move `TS_NODE_FILES` flag to `.taprc`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
