### PR TITLE
feat: config to debug TypeScript in vscode

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -63,8 +63,13 @@ const typescriptTemplate = {
     'ts-node': cliPkg.devDependencies['ts-node'],
     concurrently: cliPkg.devDependencies.concurrently,
     'fastify-tsconfig': cliPkg.devDependencies['fastify-tsconfig'],
+    nodemon: '^2.0.15',
     tap: cliPkg.devDependencies.tap,
     typescript: cliPkg.devDependencies.typescript
+  },
+  nodemonConfig: {
+    watch: ['src/'],
+    ignore: ['dist/*']
   },
   logInstructions: function (pkg) {
     log('debug', 'saved package.json')

--- a/templates/app-ts/.vscode/launch.json
+++ b/templates/app-ts/.vscode/launch.json
@@ -8,7 +8,8 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "program": "${workspaceFolder}/src/app.ts",
+            "program": "${workspaceRoot}/node_modules/.bin/fastify",
+            "args": ["start", "-l", "info", "./dist/app.js"],
             "preLaunchTask": "tsc: build - tsconfig.json",
             "outFiles": [
                 "${workspaceFolder}/dist/**/*.js"

--- a/templates/app-ts/.vscode/launch.json
+++ b/templates/app-ts/.vscode/launch.json
@@ -8,8 +8,8 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "program": "${workspaceRoot}/node_modules/.bin/fastify",
-            "args": ["start", "-l", "info", "./dist/app.js"],
+            "program": "${workspaceRoot}/node_modules/.bin/nodemon",
+            "args": ["--exec", "npm", "run", "dev"],
             "preLaunchTask": "tsc: build - tsconfig.json",
             "outFiles": [
                 "${workspaceFolder}/dist/**/*.js"

--- a/templates/app-ts/.vscode/launch.json
+++ b/templates/app-ts/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "pwa-node",
+            "request": "launch",
+            "name": "Launch Fastify",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/src/app.ts",
+            "preLaunchTask": "tsc: build - tsconfig.json",
+            "outFiles": [
+                "${workspaceFolder}/dist/**/*.js"
+            ]
+        }
+    ]
+}

--- a/templates/app-ts/tsconfig.json
+++ b/templates/app-ts/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "fastify-tsconfig",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "sourceMap": true
   },
   "include": ["src/**/*.ts"]
 }

--- a/templates/app/.vscode/launch.json
+++ b/templates/app/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "pwa-node",
+            "request": "launch",
+            "name": "Launch Fastify",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/app.js"
+        }
+    ]
+}

--- a/templates/app/.vscode/launch.json
+++ b/templates/app/.vscode/launch.json
@@ -8,7 +8,8 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "program": "${workspaceFolder}/app.js"
+            "program": "${workspaceRoot}/node_modules/.bin/fastify",
+            "args": ["start", "-l", "info", "app.js"]
         }
     ]
 }


### PR DESCRIPTION
I am proposing to add these changes to both JavaScript and TypeScript templates to allow code debugging in VSCode out of the box.
Following the request on this issue: https://github.com/fastify/fastify-cli/issues/426

![Screenshot 2021-11-11 at 11 59 45](https://user-images.githubusercontent.com/630796/141286905-70f23b58-1687-4c13-b5cf-6e5db9daa401.png)

## Steps for testing

- on this branch
- `node ./cli.js generate ../my-fastify-ts --lang ts` or `node ./cli.js generate ../my-fastify`
- `cd ../my-fastify-ts && npm install`

Now you should see the option "Launch Fastify" in the "Run and Debug" section of VSCode:

![Screenshot 2021-11-11 at 16 56 15](https://user-images.githubusercontent.com/630796/141328714-03ebf6b2-61bd-4102-8ff6-0e24e8794ff9.png)


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
