### PR TITLE
fix: downgrade help-me

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,5 @@ on:
 jobs:
   test:
     uses: fastify/workflows/.github/workflows/plugins-ci.yml@v3
+    with:
+      auto-merge-exclude: 'help-me'

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "dotenv": "^16.0.0",
     "fastify": "^4.0.0-rc.2",
     "generify": "^4.0.0",
-    "help-me": "^4.0.0",
+    "help-me": "^2.0.1",
     "is-docker": "^2.0.0",
     "make-promises-safe": "^5.1.0",
     "pino-colada": "^2.2.2",

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -2,18 +2,23 @@
 
 const t = require('tap')
 const { execSync } = require('child_process')
-const { mkdirSync } = require('fs')
+const { mkdirSync, readFileSync } = require('fs')
 const path = require('path')
 const rimraf = require('rimraf')
 
-const workdir = path.join(__dirname, 'workdir')
-const target = path.join(workdir, 'cli.test')
+t.test('generate', async (t) => {
+  const workdir = path.join(__dirname, 'workdir')
+  const target = path.join(workdir, 'cli.test')
 
-t.plan(1)
+  rimraf.sync(workdir)
+  mkdirSync(workdir, { recursive: true })
 
-rimraf.sync(workdir)
-mkdirSync(workdir, { recursive: true })
+  execSync(`node cli.js generate ${target}`)
+})
 
-execSync(`node cli.js generate ${target}`)
-
-t.pass()
+t.test('help', async t => {
+  t.equal(
+    execSync('node cli.js', { encoding: 'utf-8' }),
+    readFileSync(path.join(__dirname, '../help/help.txt'), 'utf-8')
+  )
+})


### PR DESCRIPTION
Closes #492 

I'm not sure what happened with package help-me, but the version being used here in this repo is not the latest. It's a 3.x version which doesn't seem to work correctly, while 2.x works.

Running `node cli.js`:

1. without this fix

```
$ node cli.js
There are 8 help pages that matches the given request, please disambiguate:
  * N:/nearform/fastify-cli/help/eject-ts
  * N:/nearform/fastify-cli/help/eject
  * N:/nearform/fastify-cli/help/generate-plugin
  * N:/nearform/fastify-cli/help/generate
  * N:/nearform/fastify-cli/help/help
  * N:/nearform/fastify-cli/help/print-routes
  * N:/nearform/fastify-cli/help/readme
  * N:/nearform/fastify-cli/help/start
```

2. with this fix

```
$ node cli.js
Fastify command line interface available commands are:

  * start                 start a server
  * eject                 turns your application into a standalone executable with a server.js file being added.
  * eject-ts              turns your application into a standalone executable with a server.ts file being added.
  * generate              generate a new project
  * generate-plugin       generate a new plugin project
  * readme                generate a README.md for the plugin
  * print-routes          prints the representation of the internal radix tree used by the router, useful for debugging.
  * version               the current fastify-cli version
  * help                  help about commands

Launch 'fastify help [command]' to learn more about each command.
```

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
