### PR TITLE
test: cli help

### DIFF
--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -2,18 +2,23 @@
 
 const t = require('tap')
 const { execSync } = require('child_process')
-const { mkdirSync } = require('fs')
+const { mkdirSync, readFileSync } = require('fs')
 const path = require('path')
 const rimraf = require('rimraf')
 
-const workdir = path.join(__dirname, 'workdir')
-const target = path.join(workdir, 'cli.test')
+t.test('generate', async (t) => {
+  const workdir = path.join(__dirname, 'workdir')
+  const target = path.join(workdir, 'cli.test')
 
-t.plan(1)
+  rimraf.sync(workdir)
+  mkdirSync(workdir, { recursive: true })
 
-rimraf.sync(workdir)
-mkdirSync(workdir, { recursive: true })
+  execSync(`node cli.js generate ${target}`)
+})
 
-execSync(`node cli.js generate ${target}`)
-
-t.pass()
+t.test('help', async t => {
+  t.equal(
+    execSync('node cli.js', { encoding: 'utf-8' }),
+    readFileSync(path.join(__dirname, '../help/help.txt'), 'utf-8')
+  )
+})


### PR DESCRIPTION
Adds test for cli help command, which when running on Windows will fail with help-me>2.0.1

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
