### PR TITLE
feat: support exporting server options using `--options` on ESM

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ module.exports.options = {
 }
 ```
 
+And if you are using EcmaScript Module format:
+
+```javascript
+export default async function plugin (fastify, options) {
+  // Both `/foo` and `/foo/` are registered
+  fastify.get('/foo/', async function (req, reply) {
+    return 'foo'
+  })
+}
+
+export const options = {
+  ignoreTrailingSlash: true
+}
+```
+
 If you want to use custom options for your plugin, just add them after the `--` terminator.
 
 ```js

--- a/examples/package-type-module/ESM-plugin-with-custom-server-options.js
+++ b/examples/package-type-module/ESM-plugin-with-custom-server-options.js
@@ -1,0 +1,14 @@
+// Module code is always strict mode code.
+// http://www.ecma-international.org/ecma-262/6.0/#sec-strict-mode-code
+//
+// this file has a .js extension, but the package.json in this folder contains '"type":"module"'
+
+export default async function plugin (fastify, options) {
+  fastify.get('/foo/', async function (req, reply) {
+    return 'foo'
+  })
+}
+
+export const options = {
+  ignoreTrailingSlash: true
+}

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -947,6 +947,38 @@ test('should start fastify with custom plugin options with a ESM plugin with pac
   t.end()
 })
 
+test('should start fastify with custom server options (ignoreTrailingSlash) with a ESM plugin with package.json "type":"module"', { skip: !moduleSupport }, async t => {
+  t.plan(5)
+
+  const argv = [
+    '-p',
+    getPort(),
+    './examples/package-type-module/ESM-plugin-with-custom-server-options.js',
+    '--options'
+  ]
+  const fastify = await start.start(argv)
+
+  const { response, body } = await sget({
+    method: 'GET',
+    url: `http://localhost:${fastify.server.address().port}/foo`
+  })
+
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+
+  const { response: response2, body: body2 } = await sget({
+    method: 'GET',
+    url: `http://localhost:${fastify.server.address().port}/foo/`
+  })
+
+  t.equal(response2.statusCode, 200)
+  t.equal(response2.headers['content-length'], '' + body2.length)
+
+  await fastify.close()
+  t.pass('server closed')
+  t.end()
+})
+
 test('should start fastify with custom plugin options with a CJS plugin with package.json "type":"module"', { skip: !moduleSupport }, async t => {
   t.plan(4)
 

--- a/util.js
+++ b/util.js
@@ -71,7 +71,7 @@ async function requireServerPluginFromPath (modulePath) {
   let serverPlugin
   if (type === 'module') {
     if (moduleSupport) {
-      serverPlugin = (await import(url.pathToFileURL(resolvedModulePath).href)).default
+      serverPlugin = (await import(url.pathToFileURL(resolvedModulePath).href))
     } else {
       throw new Error(`fastify-cli cannot import plugin at '${resolvedModulePath}'. Your version of node does not support ES modules. To fix this error upgrade to Node 14 or use CommonJS syntax.`)
     }
@@ -79,7 +79,7 @@ async function requireServerPluginFromPath (modulePath) {
     serverPlugin = require(resolvedModulePath)
   }
 
-  if (isInvalidAsyncPlugin(serverPlugin)) {
+  if (isInvalidAsyncPlugin(type === 'commonjs' ? serverPlugin : serverPlugin.default)) {
     throw new Error('Async/Await plugin function should contain 2 arguments. ' +
       'Refer to documentation for more information.')
   }

--- a/util.js
+++ b/util.js
@@ -71,7 +71,7 @@ async function requireServerPluginFromPath (modulePath) {
   let serverPlugin
   if (type === 'module') {
     if (moduleSupport) {
-      serverPlugin = (await import(url.pathToFileURL(resolvedModulePath).href))
+      serverPlugin = await import(url.pathToFileURL(resolvedModulePath).href)
     } else {
       throw new Error(`fastify-cli cannot import plugin at '${resolvedModulePath}'. Your version of node does not support ES modules. To fix this error upgrade to Node 14 or use CommonJS syntax.`)
     }


### PR DESCRIPTION
 This PR resolves #411
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
