### PR TITLE
fix: `argv` is callable

### DIFF
--- a/eject.js
+++ b/eject.js
@@ -19,7 +19,7 @@ function eject (dir, template) {
 }
 
 function cli (args) {
-  const opts = argv[args]
+  const opts = argv(args)
 
   let template
   if (opts.lang === 'ts' || opts.lang === 'typescript') {
@@ -28,7 +28,7 @@ function cli (args) {
     template = 'eject'
   }
 
-  eject(process.cwd(), template).catch(function (err) {
+  return eject(process.cwd(), template).catch(function (err) {
     if (err) {
       log('error', err.message)
       process.exit(1)

--- a/test/eject-ts.test.js
+++ b/test/eject-ts.test.js
@@ -11,7 +11,7 @@ const rimraf = require('rimraf')
 const walker = require('walker')
 const workdir = path.join(__dirname, 'workdir')
 const appTemplateDir = path.join(__dirname, '..', 'templates', 'eject-ts')
-const { eject } = require('../eject')
+const { eject, cli } = require('../eject')
 const expected = {};
 
 (function (cb) {
@@ -57,6 +57,16 @@ function define (t) {
     try {
       const template = 'eject-ts'
       await eject(workdir, template)
+      await verifyCopy(t, expected)
+    } catch (err) {
+      t.error(err)
+    }
+  })
+
+  test('should finish successfully with cli', async (t) => {
+    try {
+      process.chdir(workdir)
+      await cli(['--lang=typescript'])
       await verifyCopy(t, expected)
     } catch (err) {
       t.error(err)


### PR DESCRIPTION
Fixes a simple syntax error in `eject` where `argv` is not being called

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
