### PR TITLE
Add .env conf to graceful termination strategy suggested by templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ You can pass the following options via CLI arguments. You can also use `--config
 | Set the prefix                                                                                                                          | `-x`          | `--prefix`         | `FASTIFY_PREFIX`         |
 | Set the plugin timeout                                                                                                                  | `-T`          | `--plugin-timeout` | `FASTIFY_PLUGIN_TIMEOUT` |
 | Defines the maximum payload, in bytes,<br>that the server is allowed to accept                                                               |               | `--body-limit`     | `FASTIFY_BODY_LIMIT`     |
+| Set the maximum ms delay before forcefully closing pending requests after receiving SIGTERM or SIGINT signals; and uncaughtException or unhandledRejection errors (default: 500)                                                           | `-g`         | `--close-grace-delay`     | `FASTIFY_CLOSE_GRACE_DELAY`     |
 
 By default `fastify-cli` runs [`dotenv`](https://www.npmjs.com/package/dotenv), so it will load all the env variables stored in `.env` in your current working directory.
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ const appService = require('./app.js')
 app.register(appService)
 
 // delay is the number of milliseconds for the graceful close to finish
-const closeListeners = closeWithGrace({ delay: 500 }, async function ({ signal, err, manual }) {
+const closeListeners = closeWithGrace({ delay: process.env.FASTIFY_CLOSE_GRACE_DELAY || 500 }, async function ({ signal, err, manual }) {
   if (err) {
     app.log.error(err)
   }

--- a/args.js
+++ b/args.js
@@ -15,6 +15,7 @@ const DEFAULT_ARGUMENTS = {
   debugPort: 9320,
   options: false,
   pluginTimeout: 10 * 1000, // everything should load in 10 seconds
+  closeGraceDelay: 500,
   lang: 'js',
   standardlint: false
 }
@@ -25,7 +26,7 @@ module.exports = function parseArgs (args) {
     configuration: {
       'populate--': true
     },
-    number: ['port', 'inspect-port', 'body-limit', 'plugin-timeout'],
+    number: ['port', 'inspect-port', 'body-limit', 'plugin-timeout', 'close-grace-delay'],
     string: ['log-level', 'address', 'socket', 'prefix', 'ignore-watch', 'logging-module', 'debug-host', 'lang', 'require', 'config'],
     boolean: ['pretty-logs', 'options', 'watch', 'verbose-watch', 'debug', 'standardlint'],
     envPrefix: 'FASTIFY_',
@@ -44,6 +45,7 @@ module.exports = function parseArgs (args) {
       'log-level': ['l'],
       'pretty-logs': ['P'],
       'plugin-timeout': ['T'],
+      'close-grace-delay': ['g'],
       'logging-module': ['L'],
       'verbose-watch': ['V']
     }
@@ -69,6 +71,7 @@ module.exports = function parseArgs (args) {
     port: parsedArgs.port,
     bodyLimit: parsedArgs.bodyLimit,
     pluginTimeout: parsedArgs.pluginTimeout,
+    closeGraceDelay: parsedArgs.closeGraceDelay,
     pluginOptions,
     prettyLogs: parsedArgs.prettyLogs,
     options: parsedArgs.options,

--- a/help/start.txt
+++ b/help/start.txt
@@ -49,6 +49,9 @@ OPTS
   -T, --plugin-timeout
       The maximum amount of time that a plugin can take to load (default to 10 seconds).
 
+  -g, --close-grace-delay
+      The maximum amount of time before forcefully closing pending requests (default to 500 ms)
+
   -h, --help
       Show this help message
 

--- a/start.js
+++ b/start.js
@@ -137,7 +137,7 @@ async function runFastify (args, additionalOptions) {
   const appConfig = Object.assign({}, opts.pluginOptions, additionalOptions)
   await fastify.register(file.default || file, appConfig)
 
-  const closeListeners = closeWithGrace({ delay: 500 }, async function ({ signal, err, manual }) {
+  const closeListeners = closeWithGrace({ delay: opts.closeGraceDelay }, async function ({ signal, err, manual }) {
     if (err) {
       fastify.log.error(err)
     }

--- a/templates/eject-ts/server.ts
+++ b/templates/eject-ts/server.ts
@@ -17,7 +17,7 @@ const app = Fastify({
 app.register(import("./app"));
 
 // delay is the number of milliseconds for the graceful close to finish 
-const closeListeners = closeWithGrace({ delay: 500 }, async function ({ signal, err, manual }) {
+const closeListeners = closeWithGrace({ delay: parseInt(process.env.FASTIFY_CLOSE_GRACE_DELAY) || 500 }, async function ({ signal, err, manual }) {
   if (err) {
     app.log.error(err)
   }

--- a/templates/eject/server.js
+++ b/templates/eject/server.js
@@ -19,7 +19,7 @@ const appService = require('./app.js')
 app.register(appService)
 
 // delay is the number of milliseconds for the graceful close to finish
-const closeListeners = closeWithGrace({ delay: 500 }, async function ({ signal, err, manual }) {
+const closeListeners = closeWithGrace({ delay: process.env.FASTIFY_CLOSE_GRACE_DELAY || 500 }, async function ({ signal, err, manual }) {
   if (err) {
     app.log.error(err)
   }

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -18,6 +18,7 @@ test('should parse args correctly', t => {
     '--options', 'true',
     '--prefix', 'FASTIFY_',
     '--plugin-timeout', '500',
+    '--close-grace-delay', '30000',
     '--body-limit', '5242880',
     '--debug', 'true',
     '--debug-port', 1111,
@@ -42,6 +43,7 @@ test('should parse args correctly', t => {
     logLevel: 'info',
     prefix: 'FASTIFY_',
     pluginTimeout: 500,
+    closeGraceDelay: 30000,
     pluginOptions: {},
     bodyLimit: 5242880,
     debug: true,
@@ -68,6 +70,7 @@ test('should parse args with = assignment correctly', t => {
     '--options=true',
     '--prefix=FASTIFY_',
     '--plugin-timeout=500',
+    '--close-grace-delay=30000',
     '--body-limit=5242880',
     '--debug=true',
     '--debug-port', 1111,
@@ -92,6 +95,7 @@ test('should parse args with = assignment correctly', t => {
     logLevel: 'info',
     prefix: 'FASTIFY_',
     pluginTimeout: 500,
+    closeGraceDelay: 30000,
     pluginOptions: {},
     bodyLimit: 5242880,
     debug: true,
@@ -118,6 +122,7 @@ test('should parse env vars correctly', t => {
   process.env.FASTIFY_PREFIX = 'FASTIFY_'
   process.env.FASTIFY_BODY_LIMIT = '5242880'
   process.env.FASTIFY_PLUGIN_TIMEOUT = '500'
+  process.env.FASTIFY_CLOSE_GRACE_DELAY = '30000'
   process.env.FASTIFY_DEBUG = 'true'
   process.env.FASTIFY_DEBUG_PORT = '1111'
   process.env.FASTIFY_DEBUG_HOST = '1.1.1.1'
@@ -137,6 +142,7 @@ test('should parse env vars correctly', t => {
     delete process.env.FASTIFY_PREFIX
     delete process.env.FASTIFY_BODY_LIMIT
     delete process.env.FASTIFY_PLUGIN_TIMEOUT
+    delete process.env.FASTIFY_CLOSE_GRACE_DELAY
     delete process.env.FASTIFY_DEBUG
     delete process.env.FASTIFY_DEBUG_PORT
     delete process.env.FASTIFY_LOGGING_MODULE
@@ -160,6 +166,7 @@ test('should parse env vars correctly', t => {
     socket: 'fastify.io.socket:9999',
     require: './require-module.js',
     pluginTimeout: 500,
+    closeGraceDelay: 30000,
     pluginOptions: {},
     debug: true,
     debugPort: 1111,
@@ -170,7 +177,7 @@ test('should parse env vars correctly', t => {
 })
 
 test('should respect default values', t => {
-  t.plan(12)
+  t.plan(13)
 
   const argv = [
     'app.js'
@@ -186,6 +193,7 @@ test('should respect default values', t => {
   t.equal(parsedArgs.verboseWatch, false)
   t.equal(parsedArgs.logLevel, 'fatal')
   t.equal(parsedArgs.pluginTimeout, 10000)
+  t.equal(parsedArgs.closeGraceDelay, 500)
   t.equal(parsedArgs.debug, false)
   t.equal(parsedArgs.debugPort, 9320)
   t.equal(parsedArgs.loggingModule, undefined)
@@ -208,6 +216,7 @@ test('should parse custom plugin options', t => {
     '--options', 'true',
     '--prefix', 'FASTIFY_',
     '--plugin-timeout', '500',
+    '--close-grace-delay', '30000',
     '--body-limit', '5242880',
     '--debug', 'true',
     '--debug-port', 1111,
@@ -239,6 +248,7 @@ test('should parse custom plugin options', t => {
     logLevel: 'info',
     prefix: 'FASTIFY_',
     pluginTimeout: 500,
+    closeGraceDelay: 30000,
     pluginOptions: {
       a: true,
       b: true,
@@ -269,6 +279,7 @@ test('should parse config file correctly and prefer config values over default o
     port: 5000,
     bodyLimit: undefined,
     pluginTimeout: 9000,
+    closeGraceDelay: 1000,
     pluginOptions: {},
     prettyLogs: true,
     options: false,
@@ -296,6 +307,7 @@ test('should prefer command line args over config file options', t => {
     '--port', '4000',
     '--debugPort', '9320',
     '--plugin-timeout', '10000',
+    '--close-grace-delay', '30000',
     'app.js'
   ]
   const parsedArgs = parseArgs(argv)
@@ -306,6 +318,7 @@ test('should prefer command line args over config file options', t => {
     port: 4000,
     bodyLimit: undefined,
     pluginTimeout: 10000,
+    closeGraceDelay: 30000,
     pluginOptions: {},
     prettyLogs: true,
     options: false,

--- a/test/data/custom-config.js
+++ b/test/data/custom-config.js
@@ -5,5 +5,6 @@ module.exports = {
   watch: true,
   prettyLogs: true,
   debugPort: 4000,
-  pluginTimeout: 9 * 1000
+  pluginTimeout: 9 * 1000,
+  closeGraceDelay: 1000
 }


### PR DESCRIPTION
### Description 
- Add use of .env FASTIFY_CLOSE_GRACE_DELAY for closeWithGrace in templates eject/server.js
- Add --close-grace-delay parameter

Related to Issue  #531

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
