### PR TITLE
Esm help text and removed use strict

### DIFF
--- a/help/generate.txt
+++ b/help/generate.txt
@@ -6,6 +6,9 @@ in the <FOLDER>. Specify `.` to create files in the current working directory.
 
 OPTS
 
+  --esm
+      use the ESM template
+
   --integrate
       overwrite it when the target directory is the current directory (.)
 

--- a/templates/app-esm/app.js
+++ b/templates/app-esm/app.js
@@ -1,5 +1,3 @@
-'use strict'
-
 import path from 'path'
 import AutoLoad from '@fastify/autoload'
 import { fileURLToPath } from 'url'

--- a/templates/app-esm/plugins/sensible.js
+++ b/templates/app-esm/plugins/sensible.js
@@ -1,5 +1,3 @@
-'use strict'
-
 import fp from 'fastify-plugin'
 import sensible from '@fastify/sensible'
 

--- a/templates/app-esm/plugins/support.js
+++ b/templates/app-esm/plugins/support.js
@@ -1,5 +1,3 @@
-'use strict'
-
 import fp from 'fastify-plugin'
 
 // the use of fastify-plugin is required to be able

--- a/templates/app-esm/routes/example/index.js
+++ b/templates/app-esm/routes/example/index.js
@@ -1,5 +1,3 @@
-'use strict'
-
 export default async function (fastify, opts) {
   fastify.get('/', async function (request, reply) {
     return 'this is an example'

--- a/templates/app-esm/routes/root.js
+++ b/templates/app-esm/routes/root.js
@@ -1,5 +1,3 @@
-'use strict'
-
 export default async function (fastify, opts) {
   fastify.get('/', async function (request, reply) {
     return { root: true }

--- a/templates/app-esm/test/helper.js
+++ b/templates/app-esm/test/helper.js
@@ -1,5 +1,3 @@
-'use strict'
-
 // This file contains code that we reuse
 // between our tests.
 

--- a/templates/app-esm/test/plugins/support.test.js
+++ b/templates/app-esm/test/plugins/support.test.js
@@ -1,5 +1,3 @@
-'use strict'
-
 import { test } from 'tap'
 import Fastify from 'fastify'
 import Support from '../../plugins/support.js'

--- a/templates/app-esm/test/routes/example.test.js
+++ b/templates/app-esm/test/routes/example.test.js
@@ -1,5 +1,3 @@
-'use strict'
-
 import { test } from 'tap'
 import { build } from '../helper.js'
 

--- a/templates/app-esm/test/routes/root.test.js
+++ b/templates/app-esm/test/routes/root.test.js
@@ -1,5 +1,3 @@
-'use strict'
-
 import { test } from 'tap'
 import { build } from '../helper.js'
 


### PR DESCRIPTION
For the ESM template:

* Removed 'use strict' since it is part of [ESM already ](https://262.ecma-international.org/6.0/#sec-strict-mode-code)
* Added help text for `--esm` option for generate command

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
