### PR TITLE
feat: added serverOptions to test helper.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Both of these utilities have the `function(arg, pluginOptions)` parameters:
 
 - `cliArgs`: is a string or a string array within the same arguments passed to the `fastify-cli` command.
 - `pluginOptions`: is an object containing the options provided to the started plugin (eg: `app.js`).
+- `serverOptions`: is an object containing the additional options provided to fastify server, similar to the `--options` command line argument
 
 ```js
 // load the utility helper functions
@@ -368,6 +369,31 @@ test('test my application', async t => {
   t.same(res.json(), { hello: 'one' })
 })
 ```
+
+Log output is consumed by tap. If log messages should be logged to the console 
+the logger needs to be configured to output to stderr instead of stdout. 
+
+```js
+const logger = {
+  transport: {
+    target: 'pino-pretty',
+    options: {
+      destination: 2,
+    },
+  },
+}
+const argv = ['app.js']
+test('test my application with logging enabled', async t => {
+  const app = await build(argv, {}, { logger })
+  t.teardown(() => app.close())
+
+  // test your application here:
+  const res = await app.inject('/')
+  t.same(res.json(), { hello: 'one' })
+})
+```
+
+
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ There are two utilities provided:
 - `build`: builds your application and returns the `fastify` instance without calling the `listen` method.
 - `listen`: starts your application and returns the `fastify` instance listening on the configured port.
 
-Both of these utilities have the `function(arg, pluginOptions)` parameters:
+Both of these utilities have the `function(arg, pluginOptions, serverOptions)` parameters:
 
 - `cliArgs`: is a string or a string array within the same arguments passed to the `fastify-cli` command.
 - `pluginOptions`: is an object containing the options provided to the started plugin (eg: `app.js`).

--- a/helper.js
+++ b/helper.js
@@ -3,13 +3,13 @@
 const { runFastify } = require('./start')
 
 module.exports = {
-  build (args, additionalOptions = {}) {
+  build (args, additionalOptions = {}, serverOptions = {}) {
     Object.defineProperty(additionalOptions, 'ready', {
       value: true,
       enumerable: false,
       writable: false
     })
-    return runFastify(args, additionalOptions)
+    return runFastify(args, additionalOptions, serverOptions)
   },
   listen: runFastify
 }

--- a/start.js
+++ b/start.js
@@ -55,7 +55,7 @@ function stop (message) {
   exit(message)
 }
 
-async function runFastify (args, additionalOptions) {
+async function runFastify (args, additionalOptions, serverOptions) {
   const opts = parseArgs(args)
   if (opts.require) {
     if (typeof opts.require === 'string') {
@@ -124,6 +124,10 @@ async function runFastify (args, additionalOptions) {
         opts.debugHost || isDocker() ? listenAddressDocker : undefined
       )
     }
+  }
+
+  if (serverOptions) {
+    Object.assign(options, serverOptions)
   }
 
   const fastify = Fastify(


### PR DESCRIPTION
This addresses #546. I've decided to add a `serverOptions` parameter instead of using the `pluginOptions`. 
Added an example on how to enable logging during tap testing.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
