### PR TITLE
manual loading and parsing of dotenv in watch mode #558

### DIFF
--- a/lib/watch/index.js
+++ b/lib/watch/index.js
@@ -3,6 +3,7 @@
 const path = require('path')
 const cp = require('child_process')
 const chalk = require('chalk')
+const { readFileSync, existsSync } = require('fs')
 const { arrayToRegExp, logWatchVerbose } = require('./utils')
 const { GRACEFUL_SHUT } = require('./constants.js')
 
@@ -39,7 +40,15 @@ const watch = function (args, ignoreWatch, verboseWatch) {
 
   const run = (event) => {
     const childEvent = { childEvent: event }
-    const env = Object.assign({}, process.env, childEvent, require('dotenv').config().parsed)
+
+    // in order to not override existing env vars, we have to load and parse
+    // dotenv without modifying process.env
+    let dotenvParsed = {}
+    const dotenvPath = path.resolve(process.cwd(), '.env')
+    if (existsSync(dotenvPath)) {
+      dotenvParsed = require('dotenv').parse(readFileSync(dotenvPath, { encoding: 'utf-8' }))
+    }
+    const env = Object.assign({}, process.env, childEvent, dotenvParsed)
 
     const _child = cp.fork(forkPath, args, {
       env,

--- a/lib/watch/index.js
+++ b/lib/watch/index.js
@@ -37,25 +37,34 @@ const watch = function (args, ignoreWatch, verboseWatch) {
   })
 
   let readyEmitted = false
+  const envVarsToProtect = [];
 
   const run = (event) => {
     const childEvent = { childEvent: event }
 
     // in order to not override existing env vars, we have to load and parse
     // dotenv without modifying process.env
-    let dotenvParsed = {}
-    const dotenvPath = path.resolve(process.cwd(), '.env')
+    let dotenvParsed = {};
+    const dotenvPath = path.resolve(process.cwd(), '.env');
     if (existsSync(dotenvPath)) {
-      dotenvParsed = require('dotenv').parse(readFileSync(dotenvPath, { encoding: 'utf-8' }))
-      Object.keys(dotenvParsed).forEach(function (key) {
-        if (Object.prototype.hasOwnProperty.call(process.env, key)) {
-          // we do not want to overrideexisting env-vars
-          delete dotenvParsed[key]
-        }
-      })
+      dotenvParsed = require('dotenv').parse(readFileSync(dotenvPath, { encoding: 'utf-8' }));
+      if (event == 'start') {
+        // analyse which env-vars should not be overwritten
+        Object.keys(dotenvParsed).forEach(function (key) {
+          if (Object.prototype.hasOwnProperty.call(process.env, key)) {
+            // if a env var already exists with a different value
+            // than in parsed dotenv, it has to be protected
+            if (process.env[key] != dotenvParsed[key]) {
+              envVarsToProtect.push(key);
+            }
+          }
+        });
+      }
+      for (const envVarToProtect of envVarsToProtect) {
+        delete dotenvParsed[envVarToProtect];
+      }
     }
-    // const env = Object.assign({}, process.env, childEvent, dotenvParsed)
-    const env = Object.assign({}, dotenvParsed, process.env, childEvent)
+    const env = Object.assign({}, process.env, dotenvParsed, childEvent);
 
     const _child = cp.fork(forkPath, args, {
       env,

--- a/lib/watch/index.js
+++ b/lib/watch/index.js
@@ -47,8 +47,15 @@ const watch = function (args, ignoreWatch, verboseWatch) {
     const dotenvPath = path.resolve(process.cwd(), '.env')
     if (existsSync(dotenvPath)) {
       dotenvParsed = require('dotenv').parse(readFileSync(dotenvPath, { encoding: 'utf-8' }))
+      Object.keys(dotenvParsed).forEach(function (key) {
+        if (Object.prototype.hasOwnProperty.call(process.env, key)) {
+          // we do not want to overrideexisting env-vars
+          delete dotenvParsed[key]
+        }
+      })
     }
-    const env = Object.assign({}, process.env, childEvent, dotenvParsed)
+    // const env = Object.assign({}, process.env, childEvent, dotenvParsed)
+    const env = Object.assign({}, dotenvParsed, process.env, childEvent)
 
     const _child = cp.fork(forkPath, args, {
       env,


### PR DESCRIPTION
I think this could be the fix for the issue #558 that I opened.

The problem with `dotenv.config().parsed` is that `dotenv.config()` modifies the `process.env`. So the fix uses `dotenv.parse()` directly so that `process.env is untouched.

All tests are green. I will provide an additional test in the next days.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` ~and `npm run benchmark`~
- [x] tests and/or benchmarks are included
- [ ] ~documentation is changed or added~
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
