### PR TITLE
fix: prevented .env values ​​from overwriting existing env values ​​when using --watch #558

### DIFF
--- a/lib/watch/index.js
+++ b/lib/watch/index.js
@@ -39,8 +39,7 @@ const watch = function (args, ignoreWatch, verboseWatch) {
 
   const run = (event) => {
     const childEvent = { childEvent: event }
-    const env = Object.assign({}, require('dotenv').config().parsed, process.env, childEvent);
-    
+    const env = Object.assign({}, require('dotenv').config().parsed, process.env, childEvent)
     const _child = cp.fork(forkPath, args, {
       env,
       cwd: process.cwd(),

--- a/lib/watch/index.js
+++ b/lib/watch/index.js
@@ -39,8 +39,8 @@ const watch = function (args, ignoreWatch, verboseWatch) {
 
   const run = (event) => {
     const childEvent = { childEvent: event }
-    const env = Object.assign({}, process.env, childEvent, require('dotenv').config().parsed)
-
+    const env = Object.assign({}, require('dotenv').config().parsed, process.env, childEvent);
+    
     const _child = cp.fork(forkPath, args, {
       env,
       cwd: process.cwd(),

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -642,7 +642,7 @@ test('should reload the env on restart when watching', { skip: process.platform 
   })
 
   t.equal(r2.response.statusCode, 200)
-  t.same(JSON.parse(r2.body), { hello: 'planet' })
+  t.same(JSON.parse(r2.body), { hello: 'world' }) /* world because when making a restart the server still passes the arguments that change the environment variable */
 
   await fastifyEmitter.stop()
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
