### PR TITLE
fix: server config deep merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,5 @@ jobs:
   test:
     uses: fastify/workflows/.github/workflows/plugins-ci.yml@v3
     with:
+      lint: true
       auto-merge-exclude: 'help-me'

--- a/examples/plugin-with-logger.js
+++ b/examples/plugin-with-logger.js
@@ -1,0 +1,19 @@
+'use strict'
+
+module.exports = function (fastify, options, next) {
+  fastify.get('/', function (req, reply) {
+    reply.send({ hello: 'world' })
+  })
+  next()
+}
+
+module.exports.options = {
+  logger: {
+    redact: {
+      censor: '***',
+      paths: [
+        'foo'
+      ]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     ]
   },
   "dependencies": {
-    "@fastify/deepmerge": "^1.1.0",
+    "@fastify/deepmerge": "^1.2.0",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.2",
     "close-with-grace": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "standard --fix",
     "unit": "tap \"test/**/*.test.{js,ts}\" \"templates/**/*.test.{js,ts}\" --timeout 300",
     "pretest": "xcopy /e /k /i . \"..\\node_modules\\fastify-cli\" || rsync -r --exclude=node_modules ./ node_modules/fastify-cli || echo 'this is fine'",
-    "test": "npm run lint && npm run unit && npm run test:typescript",
+    "test": "npm run unit && npm run test:typescript",
     "test:typescript": "tsd templates/plugin && tsc --project templates/app-ts/tsconfig.json && del-cli templates/app-ts/dist"
   },
   "keywords": [
@@ -42,6 +42,7 @@
     ]
   },
   "dependencies": {
+    "@fastify/deepmerge": "^1.1.0",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.2",
     "close-with-grace": "^1.1.0",

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -124,3 +124,29 @@ test('should start fastify with custom logger configuration', async t => {
   t.same(lines.length, 1)
   t.same(app.log.level, 'warn')
 })
+
+test('should merge the CLI and FILE configs', async t => {
+  const argv = ['./examples/plugin-with-logger.js', '--options']
+
+  const lines = []
+  const dest = new stream.Writable({
+    write: function (chunk, enc, cb) {
+      lines.push(JSON.parse(chunk))
+      cb()
+    }
+  })
+
+  const app = await helper.listen(argv, {}, {
+    logger: {
+      level: 'warn',
+      stream: dest
+    }
+  })
+  t.teardown(() => app.close())
+  app.log.info('test')
+  t.same(lines.length, 0)
+  app.log.warn({ foo: 'test' })
+  t.same(app.log.level, 'warn')
+  t.same(lines.length, 1)
+  t.same(lines[0].foo, '***')
+})


### PR DESCRIPTION
requires https://github.com/fastify/deepmerge/pull/13

when the developer has a custom server option and needs to customize it when running the tests,  it is impossible to do it easily because the test options overwrite all the one set by the CLI arguments