### PR TITLE
fix(templates): route definition comment line

### DIFF
--- a/templates/app-esm/app.js
+++ b/templates/app-esm/app.js
@@ -21,7 +21,7 @@ export default async function (fastify, opts) {
     options: Object.assign({}, opts)
   })
 
-  // This loads all plugins defined in routes
+  // This loads all routes defined in routes
   // define your routes in one of these
   fastify.register(AutoLoad, {
     dir: path.join(__dirname, 'routes'),

--- a/templates/app-ts/src/app.ts
+++ b/templates/app-ts/src/app.ts
@@ -27,7 +27,7 @@ const app: FastifyPluginAsync<AppOptions> = async (
     options: opts
   })
 
-  // This loads all plugins defined in routes
+  // This loads all routes defined in routes
   // define your routes in one of these
   void fastify.register(AutoLoad, {
     dir: join(__dirname, 'routes'),

--- a/templates/app/app.js
+++ b/templates/app/app.js
@@ -19,7 +19,7 @@ module.exports = async function (fastify, opts) {
     options: Object.assign({}, opts)
   })
 
-  // This loads all plugins defined in routes
+  // This loads all routes defined in routes
   // define your routes in one of these
   fastify.register(AutoLoad, {
     dir: path.join(__dirname, 'routes'),


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
This patch is minor. It updates the comment line of the routes definition that was using the same as the plugins comment block.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
