### PR TITLE
fix: use address 0.0.0.0 in Kubernetes env (#579)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ You can pass the following options via CLI arguments. You can also use `--config
 | Path to logging configuration module to use                                                                                             | `-L`          | `--logging-module`  | `FASTIFY_LOGGING_MODULE` |
 | Start Fastify app in debug mode with nodejs inspector                                                                                   | `-d`          | `--debug`          | `FASTIFY_DEBUG`          |
 | Set the inspector port (default: 9320)                                                                                                  | `-I`          | `--debug-port`     | `FASTIFY_DEBUG_PORT`     |
-| Set the inspector host to listen on (default: loopback address or `0.0.0.0` inside Docker)                                              |               | `--debug-host`     | `FASTIFY_DEBUG_HOST`     |
+| Set the inspector host to listen on (default: loopback address or `0.0.0.0` inside Docker or Kubernetes)                                              |               | `--debug-host`     | `FASTIFY_DEBUG_HOST`     |
 | Prints pretty logs                                                                                                                      | `-P`          | `--pretty-logs`    | `FASTIFY_PRETTY_LOGS`    |
 | Watch process.cwd() directory for changes, recursively; when that happens, the process will auto reload                                 | `-w`          | `--watch`          | `FASTIFY_WATCH`          |
 | Ignore changes to the specified files or directories when watch is enabled. (e.g. `--ignore-watch='node_modules .git logs/error.log'` ) |               | `--ignore-watch`   | `FASTIFY_IGNORE_WATCH`   |
@@ -175,9 +175,9 @@ By default `--ignore-watch` flag is set to ignore `node_modules build dist .git 
 
 #### Containerization
 
-When deploying to a Docker, and potentially other, containers, it is advisable to set a fastify address of `0.0.0.0` because these containers do not default to exposing mapped ports to localhost.
+When deploying to a Docker container, and potentially other, containers, it is advisable to set a fastify address of `0.0.0.0` because these containers do not default to exposing mapped ports to localhost.
 
-For containers built and run specifically by the Docker Daemon, fastify-cli is able to detect that the server process is running within a Docker container and the `0.0.0.0` listen address is set automatically.
+For containers built and run specifically by the Docker Daemon or inside a Kubernetes cluster, fastify-cli is able to detect that the server process is running within a container and the `0.0.0.0` listen address is set automatically.
 
 Other containerization tools (eg. Buildah and Podman) are not detected automatically, so the `0.0.0.0` listen address must be set explicitly with either the `--address` flag or the `FASTIFY_ADDRESS` environment variable.
 

--- a/start.js
+++ b/start.js
@@ -17,7 +17,8 @@ const {
   requireModule,
   requireFastifyForModule,
   requireServerPluginFromPath,
-  showHelpForCommand
+  showHelpForCommand,
+  isKubernetes
 } = require('./util')
 
 let Fastify = null
@@ -125,7 +126,7 @@ async function runFastify (args, additionalOptions, serverOptions) {
     } else {
       require('inspector').open(
         opts.debugPort,
-        opts.debugHost || isDocker() ? listenAddressDocker : undefined
+        opts.debugHost || isDocker() || isKubernetes() ? listenAddressDocker : undefined
       )
     }
   }
@@ -165,7 +166,7 @@ async function runFastify (args, additionalOptions, serverOptions) {
     await fastify.listen({ port: opts.port, host: opts.address })
   } else if (opts.socket) {
     await fastify.listen({ path: opts.socket })
-  } else if (isDocker()) {
+  } else if (isDocker() || isKubernetes()) {
     await fastify.listen({ port: opts.port, host: listenAddressDocker })
   } else {
     await fastify.listen({ port: opts.port })

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -535,6 +535,20 @@ test('should start the server listening on 0.0.0.0 when running in docker', asyn
   t.pass('server closed')
 })
 
+test('should start the server listening on 0.0.0.0 when running in kubernetes', async t => {
+  t.plan(2)
+  process.env.KUBERNETES_SERVICE_HOST = '1.2.3.4'
+
+  const argv = ['-p', getPort(), './examples/plugin.js']
+  const fastify = await start.start(argv)
+
+  t.equal(fastify.server.address().address, '0.0.0.0')
+
+  await fastify.close()
+  delete process.env.KUBERNETES_SERVICE_HOST
+  t.pass('server closed')
+})
+
 test('should start the server with watch options that the child process restart when directory changed', { skip: process.platform === 'win32' }, async (t) => {
   t.plan(3)
   const tmpjs = path.resolve(baseFilename + '.js')

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -537,7 +537,15 @@ test('should start the server listening on 0.0.0.0 when running in docker', asyn
 
 test('should start the server listening on 0.0.0.0 when running in kubernetes', async t => {
   t.plan(2)
-  process.env.KUBERNETES_SERVICE_HOST = '1.2.3.4'
+  const isKubernetes = sinon.stub()
+  isKubernetes.returns(true)
+
+  const start = proxyquire('../start', {
+    './util': {
+      ...require('../util'),
+      isKubernetes
+    }
+  })
 
   const argv = ['-p', getPort(), './examples/plugin.js']
   const fastify = await start.start(argv)
@@ -545,7 +553,6 @@ test('should start the server listening on 0.0.0.0 when running in kubernetes', 
   t.equal(fastify.server.address().address, '0.0.0.0')
 
   await fastify.close()
-  delete process.env.KUBERNETES_SERVICE_HOST
   t.pass('server closed')
 })
 

--- a/util.js
+++ b/util.js
@@ -7,8 +7,6 @@ const resolveFrom = require('resolve-from')
 
 const moduleSupport = semver.satisfies(process.version, '>= 14 || >= 12.17.0 < 13.0.0')
 
-const isKubernetes = () => process.env.KUBERNETES_SERVICE_HOST !== undefined
-
 function exit (message) {
   if (message instanceof Error) {
     console.log(message)
@@ -98,6 +96,12 @@ function showHelpForCommand (commandName) {
   } catch (e) {
     exit(`unable to get help for command "${commandName}"`)
   }
+}
+
+function isKubernetes () {
+  // Detection based on https://kubernetes.io/docs/reference/kubectl/#in-cluster-authentication-and-namespace-overrides
+  return process.env.KUBERNETES_SERVICE_HOST !== undefined ||
+    fs.existsSync('/run/secrets/kubernetes.io/serviceaccount/token')
 }
 
 module.exports = { isKubernetes, exit, requireModule, requireFastifyForModule, showHelpForCommand, requireServerPluginFromPath }

--- a/util.js
+++ b/util.js
@@ -7,6 +7,8 @@ const resolveFrom = require('resolve-from')
 
 const moduleSupport = semver.satisfies(process.version, '>= 14 || >= 12.17.0 < 13.0.0')
 
+const isKubernetes = () => process.env.KUBERNETES_SERVICE_HOST !== undefined
+
 function exit (message) {
   if (message instanceof Error) {
     console.log(message)
@@ -98,4 +100,4 @@ function showHelpForCommand (commandName) {
   }
 }
 
-module.exports = { exit, requireModule, requireFastifyForModule, showHelpForCommand, requireServerPluginFromPath }
+module.exports = { isKubernetes, exit, requireModule, requireFastifyForModule, showHelpForCommand, requireServerPluginFromPath }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This PR adds a check so that it automatically use 0.0.0.0 when running inside a Kubernetes environment.