### PR TITLE
fix: Correct wrong instructions for typescript ejecting

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -2,7 +2,7 @@ Fastify command line interface available commands are:
 
   * start                 start a server
   * eject                 turns your application into a standalone executable with a server.js file being added.
-  * eject-ts              turns your application into a standalone executable with a server.ts file being added.
+  * eject --lang=ts       turns your application into a standalone executable with a server.ts file being added.
   * generate              generate a new project
   * generate-plugin       generate a new plugin project
   * generate-swagger      generate Swagger/OpenAPI schema for a project using @fastify/swagger


### PR DESCRIPTION
As written, the help text says that a user can run `eject-ts` to create a standalone `server.ts`. However, this is incorrect. Doing so simply creates a `server.js` -- all text following `eject` is ignored. For instance, one could run `eject-foo` and get no error and have a `server.js` generated, even though there is no `eject-foo` command. 

Instead, a user must pass in the `lang` flag: https://github.com/fastify/fastify-cli/blob/426e359f65e51a054fa89117ce729f34f88a6c37/eject.js#L25-L26

The easiest way to update this help test looks to be to use the `ts` rather than `typescript` value for `--lang`, so that it can easily fit into the existing help text format.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
