### PR TITLE
Fix return type of build in helper

### DIFF
--- a/helper.d.ts
+++ b/helper.d.ts
@@ -1,10 +1,8 @@
 import fastify from 'fastify'
 
 declare module 'fastify-cli/helper.js' {
-    type fastifyFunctionReturnType = ReturnType<fastify>;
-
     module helper {
-        export function build(argv: Array<string>, config: Object): fastifyFunctionReturnType;
+        export function build(argv: Array<string>, config: Object): ReturnType<typeof fastify>;
     }
 
     export = helper;


### PR DESCRIPTION
The call to `typeof` was missing so `build` type was incorrect and returned any.

#### Checklist

- [x] ~~run `npm run test` and `npm run benchmark`~~
- [x] ~~tests and/or benchmarks are included~~
- [x] ~~documentation is changed or added~~
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
