### PR TITLE
fix: app template options

### DIFF
--- a/templates/app/app.js
+++ b/templates/app/app.js
@@ -4,7 +4,7 @@ const path = require('path')
 const AutoLoad = require('@fastify/autoload')
 
 // Pass --options via CLI arguments in command to enable these options.
-module.exports.options = {}
+const options = {}
 
 module.exports = async function (fastify, opts) {
   // Place here your custom code!
@@ -26,3 +26,5 @@ module.exports = async function (fastify, opts) {
     options: Object.assign({}, opts)
   })
 }
+
+module.exports.options = options


### PR DESCRIPTION
Pass --options via CLI arguments in command have no effect