### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,7 @@
 
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const commist = require('commist')()
 const argv = require('yargs-parser')(process.argv)
 const help = require('help-me')({

--- a/eject.js
+++ b/eject.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const generify = require('generify')
 const argv = require('yargs-parser')
 const log = require('./log')

--- a/generate-plugin.js
+++ b/generate-plugin.js
@@ -3,15 +3,15 @@
 const {
   readFile,
   writeFile
-} = require('fs').promises
-const { existsSync } = require('fs')
-const path = require('path')
+} = require('node:fs').promises
+const { existsSync } = require('node:fs')
+const path = require('node:path')
 const chalk = require('chalk')
 const generify = require('generify')
 const argv = require('yargs-parser')
 const cliPkg = require('./package')
-const { execSync } = require('child_process')
-const { promisify } = require('util')
+const { execSync } = require('node:child_process')
+const { promisify } = require('node:util')
 const log = require('./log')
 
 const pluginTemplate = {

--- a/generate-readme.js
+++ b/generate-readme.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const { readFileSync, existsSync } = require('fs')
-const path = require('path')
+const { readFileSync, existsSync } = require('node:fs')
+const path = require('node:path')
 const generify = require('generify')
 const argv = require('yargs-parser')
-const { execSync } = require('child_process')
+const { execSync } = require('node:child_process')
 const log = require('./log')
 
 function toMarkdownList (a) {

--- a/generate.js
+++ b/generate.js
@@ -4,13 +4,13 @@ const {
   readFile,
   writeFile,
   existsSync
-} = require('fs')
-const path = require('path')
+} = require('node:fs')
+const path = require('node:path')
 const chalk = require('chalk')
 const generify = require('generify')
 const argv = require('yargs-parser')
 const cliPkg = require('./package')
-const { execSync } = require('child_process')
+const { execSync } = require('node:child_process')
 const log = require('./log')
 
 const javascriptTemplate = {

--- a/lib/watch/index.js
+++ b/lib/watch/index.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const path = require('path')
-const cp = require('child_process')
+const path = require('node:path')
+const cp = require('node:child_process')
 const chalk = require('chalk')
 const { arrayToRegExp, logWatchVerbose } = require('./utils')
 const { GRACEFUL_SHUT } = require('./constants.js')
 
-const EventEmitter = require('events')
+const EventEmitter = require('node:events')
 const chokidar = require('chokidar')
 const forkPath = path.join(__dirname, './fork.js')
 

--- a/lib/watch/utils.js
+++ b/lib/watch/utils.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const chalk = require('chalk')
-const path = require('path')
+const path = require('node:path')
 
 const arrayToRegExp = (arr) => {
   const reg = arr.map((file) => {

--- a/start.js
+++ b/start.js
@@ -124,7 +124,7 @@ async function runFastify (args, additionalOptions, serverOptions) {
     if (process.version.match(/v[0-6]\..*/g)) {
       stop('Fastify debug mode not compatible with Node.js version < 6')
     } else {
-      require('inspector').open(
+      require('node:inspector').open(
         opts.debugPort,
         opts.debugHost || isDocker() || isKubernetes() ? listenAddressDocker : undefined
       )

--- a/templates/app/app.js
+++ b/templates/app/app.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const AutoLoad = require('@fastify/autoload')
 
 // Pass --options via CLI arguments in command to enable these options.

--- a/templates/app/test/helper.js
+++ b/templates/app/test/helper.js
@@ -4,7 +4,7 @@
 // between our tests.
 
 const { build: buildApplication } = require('fastify-cli/helper')
-const path = require('path')
+const path = require('node:path')
 const AppPath = path.join(__dirname, '..', 'app.js')
 
 // Fill in this config with all the configurations

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,9 +1,9 @@
 'use strict'
 
 const t = require('tap')
-const { execSync } = require('child_process')
-const { mkdirSync, readFileSync } = require('fs')
-const path = require('path')
+const { execSync } = require('node:child_process')
+const { mkdirSync, readFileSync } = require('node:fs')
+const path = require('node:path')
 const rimraf = require('rimraf')
 
 t.test('generate', async (t) => {

--- a/test/eject-esm.test.js
+++ b/test/eject-esm.test.js
@@ -9,8 +9,8 @@ const {
   mkdirSync,
   readFileSync,
   readFile
-} = require('fs')
-const path = require('path')
+} = require('node:fs')
+const path = require('node:path')
 const rimraf = require('rimraf')
 const walker = require('walker')
 const workdir = path.join(__dirname, 'workdir')

--- a/test/eject-ts.test.js
+++ b/test/eject-ts.test.js
@@ -5,8 +5,8 @@
 process.env.TAP_BAIL = true
 
 const t = require('tap')
-const { mkdirSync, readFileSync, readFile } = require('fs')
-const path = require('path')
+const { mkdirSync, readFileSync, readFile } = require('node:fs')
+const path = require('node:path')
 const rimraf = require('rimraf')
 const walker = require('walker')
 const workdir = path.join(__dirname, 'workdir')

--- a/test/eject.test.js
+++ b/test/eject.test.js
@@ -9,8 +9,8 @@ const {
   mkdirSync,
   readFileSync,
   readFile
-} = require('fs')
-const path = require('path')
+} = require('node:fs')
+const path = require('node:path')
 const rimraf = require('rimraf')
 const walker = require('walker')
 const workdir = path.join(__dirname, 'workdir')

--- a/test/generate-esm.test.js
+++ b/test/generate-esm.test.js
@@ -11,16 +11,16 @@ const {
   readFile,
   promises: fsPromises,
   unlink
-} = require('fs')
-const path = require('path')
-const { promisify } = require('util')
+} = require('node:fs')
+const path = require('node:path')
+const { promisify } = require('node:util')
 const rimraf = require('rimraf')
 const walker = require('walker')
 const { generate, javascriptTemplate } = require('../generate')
 const workdir = path.join(__dirname, 'workdir')
 const appTemplateDir = path.join(__dirname, '..', 'templates', 'app-esm')
 const cliPkg = require('../package')
-const { exec, execSync } = require('child_process')
+const { exec, execSync } = require('node:child_process')
 const pExec = promisify(exec)
 const pUnlink = promisify(unlink)
 const minimatch = require('minimatch')

--- a/test/generate-plugin.test.js
+++ b/test/generate-plugin.test.js
@@ -9,15 +9,15 @@ const {
   mkdirSync,
   readFileSync,
   readFile
-} = require('fs')
-const path = require('path')
+} = require('node:fs')
+const path = require('node:path')
 const rimraf = require('rimraf')
 const walker = require('walker')
 const { generate, pluginTemplate } = require('../generate-plugin')
 const workdir = path.join(__dirname, 'workdir')
 const templateDir = path.join(__dirname, '..', 'templates', 'plugin')
 const cliPkg = require('../package')
-const { exec, execSync } = require('child_process')
+const { exec, execSync } = require('node:child_process')
 const minimatch = require('minimatch')
 const strip = require('strip-ansi')
 const expected = {}

--- a/test/generate-readme.test.js
+++ b/test/generate-readme.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const path = require('path')
-const fs = require('fs')
+const path = require('node:path')
+const fs = require('node:fs')
 const t = require('tap')
 const rimraf = require('rimraf')
 const { generate } = require('../generate-readme')

--- a/test/generate-swagger.test.js
+++ b/test/generate-swagger.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const t = require('tap')
 const { test } = t
 const { generateSwagger } = require('../generate-swagger')

--- a/test/generate-typescript-esm.test.js
+++ b/test/generate-typescript-esm.test.js
@@ -9,15 +9,15 @@ const {
   mkdirSync,
   readFileSync,
   readFile
-} = require('fs')
-const path = require('path')
+} = require('node:fs')
+const path = require('node:path')
 const rimraf = require('rimraf')
 const walker = require('walker')
 const { generate, typescriptTemplate } = require('../generate')
 const workdir = path.join(__dirname, 'workdir')
 const appTemplateDir = path.join(__dirname, '..', 'templates', 'app-ts')
 const cliPkg = require('../package')
-const { exec, execSync } = require('child_process')
+const { exec, execSync } = require('node:child_process')
 const minimatch = require('minimatch')
 const strip = require('strip-ansi')
 const expected = {}

--- a/test/generate-typescript.test.js
+++ b/test/generate-typescript.test.js
@@ -9,15 +9,15 @@ const {
   mkdirSync,
   readFileSync,
   readFile
-} = require('fs')
-const path = require('path')
+} = require('node:fs')
+const path = require('node:path')
 const rimraf = require('rimraf')
 const walker = require('walker')
 const { generate, typescriptTemplate } = require('../generate')
 const workdir = path.join(__dirname, 'workdir')
 const appTemplateDir = path.join(__dirname, '..', 'templates', 'app-ts')
 const cliPkg = require('../package')
-const { exec, execSync } = require('child_process')
+const { exec, execSync } = require('node:child_process')
 const minimatch = require('minimatch')
 const strip = require('strip-ansi')
 const expected = {}

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -11,16 +11,16 @@ const {
   readFile,
   promises: fsPromises,
   unlink
-} = require('fs')
-const path = require('path')
-const { promisify } = require('util')
+} = require('node:fs')
+const path = require('node:path')
+const { promisify } = require('node:util')
 const rimraf = require('rimraf')
 const walker = require('walker')
 const { generate, javascriptTemplate } = require('../generate')
 const workdir = path.join(__dirname, 'workdir')
 const appTemplateDir = path.join(__dirname, '..', 'templates', 'app')
 const cliPkg = require('../package')
-const { exec, execSync } = require('child_process')
+const { exec, execSync } = require('node:child_process')
 const pExec = promisify(exec)
 const pUnlink = promisify(unlink)
 const minimatch = require('minimatch')

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const util = require('util')
-const fs = require('fs')
-const path = require('path')
+const util = require('node:util')
+const fs = require('node:fs')
+const path = require('node:path')
 const { test } = require('tap')
-const stream = require('stream')
+const stream = require('node:stream')
 
 const helper = require('../helper')
 

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -1,14 +1,14 @@
 /* global GLOBAL_MODULE_1, GLOBAL_MODULE_2 */
 'use strict'
 
-const util = require('util')
-const { once } = require('events')
-const fs = require('fs')
-const path = require('path')
-const crypto = require('crypto')
+const util = require('node:util')
+const { once } = require('node:events')
+const fs = require('node:fs')
+const path = require('node:path')
+const crypto = require('node:crypto')
 const semver = require('semver')
 const baseFilename = path.join(__dirname, 'fixtures', `test_${crypto.randomBytes(16).toString('hex')}`)
-const { fork } = require('child_process')
+const { fork } = require('node:child_process')
 const moduleSupport = semver.satisfies(process.version, '>= 14 || >= 12.17.0 < 13.0.0')
 
 const t = require('tap')
@@ -226,7 +226,7 @@ test('should start fastify at given socket path', { skip: process.platform === '
   const fastify = await start.start(argv)
 
   await new Promise((resolve, reject) => {
-    const request = require('http').request({
+    const request = require('node:http').request({
       method: 'GET',
       path: '/',
       socketPath: sockFile

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -714,7 +714,7 @@ test('should start the server with inspect options and the defalut port is 9320'
   t.plan(3)
 
   const start = proxyquire('../start', {
-    inspector: {
+    'node:inspector': {
       open (p) {
         t.equal(p, 9320)
         t.pass('inspect open called')
@@ -733,7 +733,7 @@ test('should start the server with inspect options and use the exactly port', as
 
   const port = getPort()
   const start = proxyquire('../start', {
-    inspector: {
+    'node:inspector': {
       open (p) {
         t.equal(p, Number(port))
         t.pass('inspect open called')

--- a/util.js
+++ b/util.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const fs = require('fs')
-const path = require('path')
-const url = require('url')
+const fs = require('node:fs')
+const path = require('node:path')
+const url = require('node:url')
 const semver = require('semver')
 const pkgUp = require('pkg-up')
 const resolveFrom = require('resolve-from')


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
