### PR TITLE
Fix type resolution of helper.build() function

### DIFF
--- a/helper.d.ts
+++ b/helper.d.ts
@@ -1,7 +1,7 @@
 import fastify from 'fastify'
 
 declare module 'fastify-cli/helper.js' {
-    type fastifyFunctionReturnType = ReturnType<fastify>;
+    type fastifyFunctionReturnType = ReturnType<typeof fastify>;
 
     module helper {
         export function build(argv: Array<string>, config: Object): fastifyFunctionReturnType;


### PR DESCRIPTION
Before fix: any

![выява](https://github.com/fastify/fastify-cli/assets/1248501/eec60876-e695-44f2-8bb0-93723d29e0ea)

After: fastify.FastifyInstance<...>

![выява](https://github.com/fastify/fastify-cli/assets/1248501/8ca66eaa-8d84-4689-8d58-7628b8366f4f)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- ~~[ ] tests and/or benchmarks are included~~
- ~~[ ] documentation is changed or added~~
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Fixes: https://github.com/fastify/fastify-cli/issues/601