### PR TITLE
chore: update typescript version to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pretest": "xcopy /e /k /i . \"..\\node_modules\\fastify-cli\" || rsync -r --exclude=node_modules ./ node_modules/fastify-cli || echo 'this is fine'",
     "test-no-coverage": "npm run unit:cli && npm run unit:templates-without-ts-esm && npm run unit:template-ts-esm && npm run test:typescript",
     "test": "c8 --clean npm run test-no-coverage",
-    "test:typescript": "tsd templates/plugin && tsc --project templates/app-ts/tsconfig.json && del-cli templates/app-ts/dist"
+    "test:typescript": "tsd templates/plugin -t ./../../index.d.ts && tsc --project templates/app-ts/tsconfig.json && del-cli templates/app-ts/dist"
   },
   "keywords": [
     "fastify",
@@ -84,8 +84,8 @@
     "tap": "^16.1.0",
     "ts-node": "^10.4.0",
     "ts-standard": "^12.0.1",
-    "tsd": "^0.16.0",
-    "typescript": "^4.5.4",
+    "tsd": "^0.28.0",
+    "typescript": "^5.2.2",
     "walker": "^1.0.8"
   },
   "tsd": {

--- a/templates/plugin/test/index.test-d.ts
+++ b/templates/plugin/test/index.test-d.ts
@@ -5,7 +5,7 @@ import { expectType } from 'tsd'
 let app
 try {
   app = fastify()
-  await app.ready()
+  app.ready()
   app.register(example)
   expectType<() => string>(app.exampleDecorator)
 } catch (err) {


### PR DESCRIPTION
This PR updates typescript version to v5 of this projects in order to work with the new changes.

Closes #670 

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
