### PR TITLE
chore: replace `fastify.io` links with `fastify.dev`

### DIFF
--- a/templates/app-esm/README.md
+++ b/templates/app-esm/README.md
@@ -21,4 +21,4 @@ Run the test cases.
 
 ## Learn More
 
-To learn Fastify, check out the [Fastify documentation](https://www.fastify.dev/docs/latest/).
+To learn Fastify, check out the [Fastify documentation](https://fastify.dev/docs/latest/).

--- a/templates/app-esm/README.md
+++ b/templates/app-esm/README.md
@@ -21,4 +21,4 @@ Run the test cases.
 
 ## Learn More
 
-To learn Fastify, check out the [Fastify documentation](https://www.fastify.io/docs/latest/).
+To learn Fastify, check out the [Fastify documentation](https://www.fastify.dev/docs/latest/).

--- a/templates/app-esm/plugins/README.md
+++ b/templates/app-esm/plugins/README.md
@@ -11,6 +11,6 @@ that will then be used in the rest of your application.
 
 Check out:
 
-* [The hitchhiker's guide to plugins](https://www.fastify.io/docs/latest/Guides/Plugins-Guide/)
-* [Fastify decorators](https://www.fastify.io/docs/latest/Reference/Decorators/).
-* [Fastify lifecycle](https://www.fastify.io/docs/latest/Reference/Lifecycle/).
+* [The hitchhiker's guide to plugins](https://www.fastify.dev/docs/latest/Guides/Plugins-Guide/)
+* [Fastify decorators](https://www.fastify.dev/docs/latest/Reference/Decorators/).
+* [Fastify lifecycle](https://www.fastify.dev/docs/latest/Reference/Lifecycle/).

--- a/templates/app-esm/plugins/README.md
+++ b/templates/app-esm/plugins/README.md
@@ -11,6 +11,6 @@ that will then be used in the rest of your application.
 
 Check out:
 
-* [The hitchhiker's guide to plugins](https://www.fastify.dev/docs/latest/Guides/Plugins-Guide/)
-* [Fastify decorators](https://www.fastify.dev/docs/latest/Reference/Decorators/).
-* [Fastify lifecycle](https://www.fastify.dev/docs/latest/Reference/Lifecycle/).
+* [The hitchhiker's guide to plugins](https://fastify.dev/docs/latest/Guides/Plugins-Guide/)
+* [Fastify decorators](https://fastify.dev/docs/latest/Reference/Decorators/).
+* [Fastify lifecycle](https://fastify.dev/docs/latest/Reference/Lifecycle/).

--- a/templates/app-esm/routes/README.md
+++ b/templates/app-esm/routes/README.md
@@ -7,7 +7,7 @@ to independently deploy some of those.
 In this folder you should define all the routes that define the endpoints
 of your web application.
 Each service is a [Fastify
-plugin](https://www.fastify.io/docs/latest/Reference/Plugins/), it is
+plugin](https://www.fastify.dev/docs/latest/Reference/Plugins/), it is
 encapsulated (it can have its own independent plugins) and it is
 typically stored in a file; be careful to group your routes logically,
 e.g. all `/users` routes in a `users.js` file. We have added
@@ -21,7 +21,7 @@ and eventually extract them.
 
 If you need to share functionality between routes, place that
 functionality into the `plugins` folder, and share it via
-[decorators](https://www.fastify.io/docs/latest/Reference/Decorators/).
+[decorators](https://www.fastify.dev/docs/latest/Reference/Decorators/).
 
 If you're a bit confused about using `async/await` to write routes, you would
-better take a look at [Promise resolution](https://www.fastify.io/docs/latest/Reference/Routes/#promise-resolution) for more details.
+better take a look at [Promise resolution](https://www.fastify.dev/docs/latest/Reference/Routes/#promise-resolution) for more details.

--- a/templates/app-esm/routes/README.md
+++ b/templates/app-esm/routes/README.md
@@ -7,7 +7,7 @@ to independently deploy some of those.
 In this folder you should define all the routes that define the endpoints
 of your web application.
 Each service is a [Fastify
-plugin](https://www.fastify.dev/docs/latest/Reference/Plugins/), it is
+plugin](https://fastify.dev/docs/latest/Reference/Plugins/), it is
 encapsulated (it can have its own independent plugins) and it is
 typically stored in a file; be careful to group your routes logically,
 e.g. all `/users` routes in a `users.js` file. We have added
@@ -21,7 +21,7 @@ and eventually extract them.
 
 If you need to share functionality between routes, place that
 functionality into the `plugins` folder, and share it via
-[decorators](https://www.fastify.dev/docs/latest/Reference/Decorators/).
+[decorators](https://fastify.dev/docs/latest/Reference/Decorators/).
 
 If you're a bit confused about using `async/await` to write routes, you would
-better take a look at [Promise resolution](https://www.fastify.dev/docs/latest/Reference/Routes/#promise-resolution) for more details.
+better take a look at [Promise resolution](https://fastify.dev/docs/latest/Reference/Routes/#promise-resolution) for more details.

--- a/templates/app-ts-esm/README.md
+++ b/templates/app-ts-esm/README.md
@@ -20,4 +20,4 @@ Run the test cases.
 
 ## Learn More
 
-To learn Fastify, check out the [Fastify documentation](https://www.fastify.dev/docs/latest/).
+To learn Fastify, check out the [Fastify documentation](https://fastify.dev/docs/latest/).

--- a/templates/app-ts-esm/README.md
+++ b/templates/app-ts-esm/README.md
@@ -20,4 +20,4 @@ Run the test cases.
 
 ## Learn More
 
-To learn Fastify, check out the [Fastify documentation](https://www.fastify.io/docs/latest/).
+To learn Fastify, check out the [Fastify documentation](https://www.fastify.dev/docs/latest/).

--- a/templates/app-ts-esm/src/plugins/README.md
+++ b/templates/app-ts-esm/src/plugins/README.md
@@ -11,6 +11,6 @@ that will then be used in the rest of your application.
 
 Check out:
 
-* [The hitchhiker's guide to plugins](https://www.fastify.io/docs/latest/Guides/Plugins-Guide/)
-* [Fastify decorators](https://www.fastify.io/docs/latest/Reference/Decorators/).
-* [Fastify lifecycle](https://www.fastify.io/docs/latest/Reference/Lifecycle/).
+* [The hitchhiker's guide to plugins](https://www.fastify.dev/docs/latest/Guides/Plugins-Guide/)
+* [Fastify decorators](https://www.fastify.dev/docs/latest/Reference/Decorators/).
+* [Fastify lifecycle](https://www.fastify.dev/docs/latest/Reference/Lifecycle/).

--- a/templates/app-ts-esm/src/plugins/README.md
+++ b/templates/app-ts-esm/src/plugins/README.md
@@ -11,6 +11,6 @@ that will then be used in the rest of your application.
 
 Check out:
 
-* [The hitchhiker's guide to plugins](https://www.fastify.dev/docs/latest/Guides/Plugins-Guide/)
-* [Fastify decorators](https://www.fastify.dev/docs/latest/Reference/Decorators/).
-* [Fastify lifecycle](https://www.fastify.dev/docs/latest/Reference/Lifecycle/).
+* [The hitchhiker's guide to plugins](https://fastify.dev/docs/latest/Guides/Plugins-Guide/)
+* [Fastify decorators](https://fastify.dev/docs/latest/Reference/Decorators/).
+* [Fastify lifecycle](https://fastify.dev/docs/latest/Reference/Lifecycle/).

--- a/templates/app-ts-esm/src/routes/README.md
+++ b/templates/app-ts-esm/src/routes/README.md
@@ -7,7 +7,7 @@ to independently deploy some of those.
 In this folder you should define all the routes that define the endpoints
 of your web application.
 Each service is a [Fastify
-plugin](https://www.fastify.io/docs/latest/Reference/Plugins/), it is
+plugin](https://www.fastify.dev/docs/latest/Reference/Plugins/), it is
 encapsulated (it can have its own independent plugins) and it is
 typically stored in a file; be careful to group your routes logically,
 e.g. all `/users` routes in a `users.js` file. We have added
@@ -21,4 +21,4 @@ and eventually extract them.
 
 If you need to share functionality between routes, place that
 functionality into the `plugins` folder, and share it via
-[decorators](https://www.fastify.io/docs/latest/Reference/Decorators/).
+[decorators](https://www.fastify.dev/docs/latest/Reference/Decorators/).

--- a/templates/app-ts-esm/src/routes/README.md
+++ b/templates/app-ts-esm/src/routes/README.md
@@ -7,7 +7,7 @@ to independently deploy some of those.
 In this folder you should define all the routes that define the endpoints
 of your web application.
 Each service is a [Fastify
-plugin](https://www.fastify.dev/docs/latest/Reference/Plugins/), it is
+plugin](https://fastify.dev/docs/latest/Reference/Plugins/), it is
 encapsulated (it can have its own independent plugins) and it is
 typically stored in a file; be careful to group your routes logically,
 e.g. all `/users` routes in a `users.js` file. We have added
@@ -21,4 +21,4 @@ and eventually extract them.
 
 If you need to share functionality between routes, place that
 functionality into the `plugins` folder, and share it via
-[decorators](https://www.fastify.dev/docs/latest/Reference/Decorators/).
+[decorators](https://fastify.dev/docs/latest/Reference/Decorators/).

--- a/templates/app-ts/README.md
+++ b/templates/app-ts/README.md
@@ -20,4 +20,4 @@ Run the test cases.
 
 ## Learn More
 
-To learn Fastify, check out the [Fastify documentation](https://www.fastify.dev/docs/latest/).
+To learn Fastify, check out the [Fastify documentation](https://fastify.dev/docs/latest/).

--- a/templates/app-ts/README.md
+++ b/templates/app-ts/README.md
@@ -20,4 +20,4 @@ Run the test cases.
 
 ## Learn More
 
-To learn Fastify, check out the [Fastify documentation](https://www.fastify.io/docs/latest/).
+To learn Fastify, check out the [Fastify documentation](https://www.fastify.dev/docs/latest/).

--- a/templates/app-ts/src/plugins/README.md
+++ b/templates/app-ts/src/plugins/README.md
@@ -11,6 +11,6 @@ that will then be used in the rest of your application.
 
 Check out:
 
-* [The hitchhiker's guide to plugins](https://www.fastify.io/docs/latest/Guides/Plugins-Guide/)
-* [Fastify decorators](https://www.fastify.io/docs/latest/Reference/Decorators/).
-* [Fastify lifecycle](https://www.fastify.io/docs/latest/Reference/Lifecycle/).
+* [The hitchhiker's guide to plugins](https://www.fastify.dev/docs/latest/Guides/Plugins-Guide/)
+* [Fastify decorators](https://www.fastify.dev/docs/latest/Reference/Decorators/).
+* [Fastify lifecycle](https://www.fastify.dev/docs/latest/Reference/Lifecycle/).

--- a/templates/app-ts/src/plugins/README.md
+++ b/templates/app-ts/src/plugins/README.md
@@ -11,6 +11,6 @@ that will then be used in the rest of your application.
 
 Check out:
 
-* [The hitchhiker's guide to plugins](https://www.fastify.dev/docs/latest/Guides/Plugins-Guide/)
-* [Fastify decorators](https://www.fastify.dev/docs/latest/Reference/Decorators/).
-* [Fastify lifecycle](https://www.fastify.dev/docs/latest/Reference/Lifecycle/).
+* [The hitchhiker's guide to plugins](https://fastify.dev/docs/latest/Guides/Plugins-Guide/)
+* [Fastify decorators](https://fastify.dev/docs/latest/Reference/Decorators/).
+* [Fastify lifecycle](https://fastify.dev/docs/latest/Reference/Lifecycle/).

--- a/templates/app-ts/src/routes/README.md
+++ b/templates/app-ts/src/routes/README.md
@@ -7,7 +7,7 @@ to independently deploy some of those.
 In this folder you should define all the routes that define the endpoints
 of your web application.
 Each service is a [Fastify
-plugin](https://www.fastify.io/docs/latest/Reference/Plugins/), it is
+plugin](https://www.fastify.dev/docs/latest/Reference/Plugins/), it is
 encapsulated (it can have its own independent plugins) and it is
 typically stored in a file; be careful to group your routes logically,
 e.g. all `/users` routes in a `users.js` file. We have added
@@ -21,4 +21,4 @@ and eventually extract them.
 
 If you need to share functionality between routes, place that
 functionality into the `plugins` folder, and share it via
-[decorators](https://www.fastify.io/docs/latest/Reference/Decorators/).
+[decorators](https://www.fastify.dev/docs/latest/Reference/Decorators/).

--- a/templates/app-ts/src/routes/README.md
+++ b/templates/app-ts/src/routes/README.md
@@ -7,7 +7,7 @@ to independently deploy some of those.
 In this folder you should define all the routes that define the endpoints
 of your web application.
 Each service is a [Fastify
-plugin](https://www.fastify.dev/docs/latest/Reference/Plugins/), it is
+plugin](https://fastify.dev/docs/latest/Reference/Plugins/), it is
 encapsulated (it can have its own independent plugins) and it is
 typically stored in a file; be careful to group your routes logically,
 e.g. all `/users` routes in a `users.js` file. We have added
@@ -21,4 +21,4 @@ and eventually extract them.
 
 If you need to share functionality between routes, place that
 functionality into the `plugins` folder, and share it via
-[decorators](https://www.fastify.dev/docs/latest/Reference/Decorators/).
+[decorators](https://fastify.dev/docs/latest/Reference/Decorators/).

--- a/templates/app/README.md
+++ b/templates/app/README.md
@@ -20,4 +20,4 @@ Run the test cases.
 
 ## Learn More
 
-To learn Fastify, check out the [Fastify documentation](https://www.fastify.dev/docs/latest/).
+To learn Fastify, check out the [Fastify documentation](https://fastify.dev/docs/latest/).

--- a/templates/app/README.md
+++ b/templates/app/README.md
@@ -20,4 +20,4 @@ Run the test cases.
 
 ## Learn More
 
-To learn Fastify, check out the [Fastify documentation](https://www.fastify.io/docs/latest/).
+To learn Fastify, check out the [Fastify documentation](https://www.fastify.dev/docs/latest/).

--- a/templates/app/plugins/README.md
+++ b/templates/app/plugins/README.md
@@ -11,6 +11,6 @@ that will then be used in the rest of your application.
 
 Check out:
 
-* [The hitchhiker's guide to plugins](https://www.fastify.io/docs/latest/Guides/Plugins-Guide/)
-* [Fastify decorators](https://www.fastify.io/docs/latest/Reference/Decorators/).
-* [Fastify lifecycle](https://www.fastify.io/docs/latest/Reference/Lifecycle/).
+* [The hitchhiker's guide to plugins](https://www.fastify.dev/docs/latest/Guides/Plugins-Guide/)
+* [Fastify decorators](https://www.fastify.dev/docs/latest/Reference/Decorators/).
+* [Fastify lifecycle](https://www.fastify.dev/docs/latest/Reference/Lifecycle/).

--- a/templates/app/plugins/README.md
+++ b/templates/app/plugins/README.md
@@ -11,6 +11,6 @@ that will then be used in the rest of your application.
 
 Check out:
 
-* [The hitchhiker's guide to plugins](https://www.fastify.dev/docs/latest/Guides/Plugins-Guide/)
-* [Fastify decorators](https://www.fastify.dev/docs/latest/Reference/Decorators/).
-* [Fastify lifecycle](https://www.fastify.dev/docs/latest/Reference/Lifecycle/).
+* [The hitchhiker's guide to plugins](https://fastify.dev/docs/latest/Guides/Plugins-Guide/)
+* [Fastify decorators](https://fastify.dev/docs/latest/Reference/Decorators/).
+* [Fastify lifecycle](https://fastify.dev/docs/latest/Reference/Lifecycle/).

--- a/templates/app/routes/README.md
+++ b/templates/app/routes/README.md
@@ -7,7 +7,7 @@ to independently deploy some of those.
 In this folder you should define all the routes that define the endpoints
 of your web application.
 Each service is a [Fastify
-plugin](https://www.fastify.io/docs/latest/Reference/Plugins/), it is
+plugin](https://www.fastify.dev/docs/latest/Reference/Plugins/), it is
 encapsulated (it can have its own independent plugins) and it is
 typically stored in a file; be careful to group your routes logically,
 e.g. all `/users` routes in a `users.js` file. We have added
@@ -21,7 +21,7 @@ and eventually extract them.
 
 If you need to share functionality between routes, place that
 functionality into the `plugins` folder, and share it via
-[decorators](https://www.fastify.io/docs/latest/Reference/Decorators/).
+[decorators](https://www.fastify.dev/docs/latest/Reference/Decorators/).
 
 If you're a bit confused about using `async/await` to write routes, you would
-better take a look at [Promise resolution](https://www.fastify.io/docs/latest/Reference/Routes/#promise-resolution) for more details.
+better take a look at [Promise resolution](https://www.fastify.dev/docs/latest/Reference/Routes/#promise-resolution) for more details.

--- a/templates/app/routes/README.md
+++ b/templates/app/routes/README.md
@@ -7,7 +7,7 @@ to independently deploy some of those.
 In this folder you should define all the routes that define the endpoints
 of your web application.
 Each service is a [Fastify
-plugin](https://www.fastify.dev/docs/latest/Reference/Plugins/), it is
+plugin](https://fastify.dev/docs/latest/Reference/Plugins/), it is
 encapsulated (it can have its own independent plugins) and it is
 typically stored in a file; be careful to group your routes logically,
 e.g. all `/users` routes in a `users.js` file. We have added
@@ -21,7 +21,7 @@ and eventually extract them.
 
 If you need to share functionality between routes, place that
 functionality into the `plugins` folder, and share it via
-[decorators](https://www.fastify.dev/docs/latest/Reference/Decorators/).
+[decorators](https://fastify.dev/docs/latest/Reference/Decorators/).
 
 If you're a bit confused about using `async/await` to write routes, you would
-better take a look at [Promise resolution](https://www.fastify.dev/docs/latest/Reference/Routes/#promise-resolution) for more details.
+better take a look at [Promise resolution](https://fastify.dev/docs/latest/Reference/Routes/#promise-resolution) for more details.

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -9,8 +9,8 @@ test('should parse args correctly', t => {
 
   const argv = [
     '--port', '7777',
-    '--address', 'fastify.io:9999',
-    '--socket', 'fastify.io.socket:9999',
+    '--address', 'fastify.dev:9999',
+    '--socket', 'fastify.dev.socket:9999',
     '--require', './require-module.js',
     '--log-level', 'info',
     '--pretty-logs', 'true',
@@ -39,8 +39,8 @@ test('should parse args correctly', t => {
     ignoreWatch: 'node_modules build dist .git bower_components logs .swp .nyc_output ignoreme.js',
     verboseWatch: true,
     port: 7777,
-    address: 'fastify.io:9999',
-    socket: 'fastify.io.socket:9999',
+    address: 'fastify.dev:9999',
+    socket: 'fastify.dev.socket:9999',
     require: './require-module.js',
     logLevel: 'info',
     prefix: 'FASTIFY_',
@@ -64,8 +64,8 @@ test('should parse args with = assignment correctly', t => {
 
   const argv = [
     '--port=7777',
-    '--address=fastify.io:9999',
-    '--socket=fastify.io.socket:9999',
+    '--address=fastify.dev:9999',
+    '--socket=fastify.dev.socket:9999',
     '--require', './require-module.js',
     '--log-level=info',
     '--pretty-logs=true',
@@ -94,8 +94,8 @@ test('should parse args with = assignment correctly', t => {
     ignoreWatch: 'node_modules build dist .git bower_components logs .swp .nyc_output ignoreme.js',
     verboseWatch: true,
     port: 7777,
-    address: 'fastify.io:9999',
-    socket: 'fastify.io.socket:9999',
+    address: 'fastify.dev:9999',
+    socket: 'fastify.dev.socket:9999',
     require: './require-module.js',
     logLevel: 'info',
     prefix: 'FASTIFY_',
@@ -118,8 +118,8 @@ test('should parse env vars correctly', t => {
   t.plan(1)
 
   process.env.FASTIFY_PORT = '7777'
-  process.env.FASTIFY_ADDRESS = 'fastify.io:9999'
-  process.env.FASTIFY_SOCKET = 'fastify.io.socket:9999'
+  process.env.FASTIFY_ADDRESS = 'fastify.dev:9999'
+  process.env.FASTIFY_SOCKET = 'fastify.dev.socket:9999'
   process.env.FASTIFY_REQUIRE = './require-module.js'
   process.env.FASTIFY_LOG_LEVEL = 'info'
   process.env.FASTIFY_PRETTY_LOGS = 'true'
@@ -166,12 +166,12 @@ test('should parse env vars correctly', t => {
     watch: true,
     ignoreWatch: 'node_modules build dist .git bower_components logs .swp .nyc_output ignoreme.js',
     verboseWatch: true,
-    address: 'fastify.io:9999',
+    address: 'fastify.dev:9999',
     bodyLimit: 5242880,
     logLevel: 'info',
     port: 7777,
     prefix: 'FASTIFY_',
-    socket: 'fastify.io.socket:9999',
+    socket: 'fastify.dev.socket:9999',
     require: './require-module.js',
     pluginTimeout: 500,
     closeGraceDelay: 30000,
@@ -216,8 +216,8 @@ test('should parse custom plugin options', t => {
 
   const argv = [
     '--port', '7777',
-    '--address', 'fastify.io:9999',
-    '--socket', 'fastify.io.socket:9999',
+    '--address', 'fastify.dev:9999',
+    '--socket', 'fastify.dev.socket:9999',
     '--require', './require-module.js',
     '--log-level', 'info',
     '--pretty-logs', 'true',
@@ -253,8 +253,8 @@ test('should parse custom plugin options', t => {
     ignoreWatch: 'node_modules build dist .git bower_components logs .swp .nyc_output ignoreme.js',
     verboseWatch: true,
     port: 7777,
-    address: 'fastify.io:9999',
-    socket: 'fastify.io.socket:9999',
+    address: 'fastify.dev:9999',
+    socket: 'fastify.dev.socket:9999',
     require: './require-module.js',
     logLevel: 'info',
     prefix: 'FASTIFY_',
@@ -304,7 +304,7 @@ test('should parse config file correctly and prefer config values over default o
     ignoreWatch: 'node_modules build dist .git bower_components logs .swp .nyc_output',
     verboseWatch: false,
     logLevel: 'fatal',
-    address: 'fastify.io:9999',
+    address: 'fastify.dev:9999',
     socket: undefined,
     require: undefined,
     prefix: 'FASTIFY_',
@@ -346,7 +346,7 @@ test('should prefer command line args over config file options', t => {
     ignoreWatch: 'node_modules build dist .git bower_components logs .swp .nyc_output',
     verboseWatch: false,
     logLevel: 'fatal',
-    address: 'fastify.io:9999',
+    address: 'fastify.dev:9999',
     socket: undefined,
     require: undefined,
     prefix: 'FASTIFY_',

--- a/test/data/custom-config.js
+++ b/test/data/custom-config.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   port: 5000,
-  address: 'fastify.io:9999',
+  address: 'fastify.dev:9999',
   prefix: 'FASTIFY_',
   watch: true,
   prettyLogs: true,


### PR DESCRIPTION
See https://github.com/fastify/ajv-compiler/pull/115

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
