### PR TITLE
fix: add missing `c8` dev dependency

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -63,6 +63,7 @@ const typescriptTemplate = {
   },
   devDependencies: {
     '@types/node': cliPkg.devDependencies['@types/node'],
+    c8: cliPkg.devDependencies.c8,
     'ts-node': cliPkg.devDependencies['ts-node'],
     concurrently: cliPkg.devDependencies.concurrently,
     'fastify-tsconfig': cliPkg.devDependencies['fastify-tsconfig'],

--- a/test/generate-typescript.test.js
+++ b/test/generate-typescript.test.js
@@ -101,7 +101,7 @@ function define (t) {
   })
 
   test('should finish successfully with typescript template', async (t) => {
-    t.plan(24 + Object.keys(expected).length)
+    t.plan(25 + Object.keys(expected).length)
     try {
       await generate(workdir, typescriptTemplate)
       await verifyPkg(t)
@@ -138,6 +138,7 @@ function define (t) {
         t.equal(pkg.dependencies['@fastify/autoload'], cliPkg.devDependencies['@fastify/autoload'])
         t.equal(pkg.dependencies['@fastify/sensible'], cliPkg.devDependencies['@fastify/sensible'])
         t.equal(pkg.devDependencies['@types/node'], cliPkg.devDependencies['@types/node'])
+        t.equal(pkg.devDependencies['c8'], cliPkg.devDependencies['c8'])
         t.equal(pkg.devDependencies['ts-node'], cliPkg.devDependencies['ts-node'])
         t.equal(pkg.devDependencies.concurrently, cliPkg.devDependencies.concurrently)
         t.equal(pkg.devDependencies.typescript, cliPkg.devDependencies.typescript)

--- a/test/generate-typescript.test.js
+++ b/test/generate-typescript.test.js
@@ -138,7 +138,7 @@ function define (t) {
         t.equal(pkg.dependencies['@fastify/autoload'], cliPkg.devDependencies['@fastify/autoload'])
         t.equal(pkg.dependencies['@fastify/sensible'], cliPkg.devDependencies['@fastify/sensible'])
         t.equal(pkg.devDependencies['@types/node'], cliPkg.devDependencies['@types/node'])
-        t.equal(pkg.devDependencies['c8'], cliPkg.devDependencies['c8'])
+        t.equal(pkg.devDependencies.c8, cliPkg.devDependencies.c8)
         t.equal(pkg.devDependencies['ts-node'], cliPkg.devDependencies['ts-node'])
         t.equal(pkg.devDependencies.concurrently, cliPkg.devDependencies.concurrently)
         t.equal(pkg.devDependencies.typescript, cliPkg.devDependencies.typescript)


### PR DESCRIPTION
Fixes https://github.com/fastify/fastify-cli/issues/702

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
