### PR TITLE
Remove build:ts step from npm start Task

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -48,7 +48,7 @@ const typescriptTemplate = {
   main: 'app.ts',
   scripts: {
     test: 'npm run build:ts && tsc -p test/tsconfig.json && c8 node --test -r ts-node/register test/**/*.ts',
-    start: 'npm run build:ts && fastify start -l info dist/app.js',
+    start: 'fastify start -l info dist/app.js',
     'build:ts': 'tsc',
     'watch:ts': 'tsc -w',
     dev: 'npm run build:ts && concurrently -k -p "[{name}]" -n "TypeScript,App" -c "yellow.bold,cyan.bold" "npm:watch:ts" "npm:dev:start"',

--- a/test/generate-typescript-esm.test.js
+++ b/test/generate-typescript-esm.test.js
@@ -130,7 +130,7 @@ function define (t) {
         // so for local tests we need to accept MIT as well
         t.ok(pkg.license === 'ISC' || pkg.license === 'MIT')
         t.equal(pkg.scripts.test, 'npm run build:ts && tsc -p test/tsconfig.json && FASTIFY_AUTOLOAD_TYPESCRIPT=1 node --test --experimental-test-coverage --loader ts-node/esm test/**/*.ts')
-        t.equal(pkg.scripts.start, 'npm run build:ts && fastify start -l info dist/app.js')
+        t.equal(pkg.scripts.start, 'fastify start -l info dist/app.js')
         t.equal(pkg.scripts['build:ts'], 'tsc')
         t.equal(pkg.scripts['watch:ts'], 'tsc -w')
         t.equal(pkg.scripts.dev, 'npm run build:ts && concurrently -k -p "[{name}]" -n "TypeScript,App" -c "yellow.bold,cyan.bold" "npm:watch:ts" "npm:dev:start"')

--- a/test/generate-typescript.test.js
+++ b/test/generate-typescript.test.js
@@ -127,7 +127,7 @@ function define (t) {
         // so for local tests we need to accept MIT as well
         t.ok(pkg.license === 'ISC' || pkg.license === 'MIT')
         t.equal(pkg.scripts.test, 'npm run build:ts && tsc -p test/tsconfig.json && c8 node --test -r ts-node/register test/**/*.ts')
-        t.equal(pkg.scripts.start, 'npm run build:ts && fastify start -l info dist/app.js')
+        t.equal(pkg.scripts.start, 'fastify start -l info dist/app.js')
         t.equal(pkg.scripts['build:ts'], 'tsc')
         t.equal(pkg.scripts['watch:ts'], 'tsc -w')
         t.equal(pkg.scripts.dev, 'npm run build:ts && concurrently -k -p "[{name}]" -n "TypeScript,App" -c "yellow.bold,cyan.bold" "npm:watch:ts" "npm:dev:start"')


### PR DESCRIPTION
[

#### Checklist

- [x] run `npm run test` 
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
](https://github.com/fastify/fastify-cli/issues/705)