### PR TITLE
fix: make-promises-safe is no longer required

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,11 +236,6 @@ app.listen({ port: process.env.PORT || 3000 }, (err) => {
 })
 ```
 
-#### Unhandled rejections
-
-fastify-cli uses [make-promises-safe](https://github.com/mcollina/make-promises-safe) to avoid memory leaks
-in case of an `'unhandledRejection'`.
-
 ### generate
 
 `fastify-cli` can also help with generating some project scaffolding to

--- a/generate-swagger.js
+++ b/generate-swagger.js
@@ -35,9 +35,6 @@ async function generateSwagger (args) {
     return showHelpForCommand('generate-swagger')
   }
 
-  // we start crashing on unhandledRejection
-  require('make-promises-safe')
-
   loadModules(opts)
 
   const fastify = await runFastify(opts)

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "generify": "^4.0.0",
     "help-me": "^4.0.1",
     "is-docker": "^2.0.0",
-    "make-promises-safe": "^5.1.0",
     "pino-pretty": "^10.1.0",
     "pkg-up": "^3.1.0",
     "resolve-from": "^5.0.0",

--- a/print-plugins.js
+++ b/print-plugins.js
@@ -32,9 +32,6 @@ function printPlugins (args) {
     return showHelpForCommand('print-plugins')
   }
 
-  // we start crashing on unhandledRejection
-  require('make-promises-safe')
-
   loadModules(opts)
 
   return runFastify(opts)

--- a/print-routes.js
+++ b/print-routes.js
@@ -32,9 +32,6 @@ function printRoutes (args) {
     return showHelpForCommand('print-routes')
   }
 
-  // we start crashing on unhandledRejection
-  require('make-promises-safe')
-
   loadModules(opts)
 
   return runFastify(opts)

--- a/start.js
+++ b/start.js
@@ -44,9 +44,6 @@ async function start (args) {
     return showHelpForCommand('start')
   }
 
-  // we start crashing on unhandledRejection
-  require('make-promises-safe')
-
   loadModules(opts)
 
   if (opts.watch) {


### PR DESCRIPTION
make-promises-safe is not required in Node.js 15+. I presumed this would be non-breaking for fastify-cli because the test matrix is only 18, 20 & 21. I left in the tests that were added when make-promises-safe was added, and they continue to pass locally on Node.js 20 & 21. I have an issue with the tests in master hanging in Node 18, so couldn't confirm that certainly but there weren't any failures before the hang.

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
