### PR TITLE
fix: add missing parameter for type of `build` function in `fastify-cli/helper`

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,9 +349,9 @@ There are two utilities provided:
 - `build`: builds your application and returns the `fastify` instance without calling the `listen` method.
 - `listen`: starts your application and returns the `fastify` instance listening on the configured port.
 
-Both of these utilities have the `function(arg, pluginOptions, serverOptions)` parameters:
+Both of these utilities have the `function(args, pluginOptions, serverOptions)` parameters:
 
-- `cliArgs`: is a string or a string array within the same arguments passed to the `fastify-cli` command.
+- `args`: is a string or a string array within the same arguments passed to the `fastify-cli` command.
 - `pluginOptions`: is an object containing the options provided to the started plugin (eg: `app.js`).
 - `serverOptions`: is an object containing the additional options provided to fastify server, similar to the `--options` command line argument
 

--- a/helper.d.ts
+++ b/helper.d.ts
@@ -2,7 +2,7 @@ import fastify from 'fastify'
 
 declare module 'fastify-cli/helper.js' {
     module helper {
-        export function build(argv: Array<string>, config: Object): ReturnType<typeof fastify>;
+        export function build(args: Array<string>, additionalOptions: Object, serverOptions: Object): ReturnType<typeof fastify>;
     }
 
     export = helper;

--- a/helper.d.ts
+++ b/helper.d.ts
@@ -2,7 +2,7 @@ import fastify from 'fastify'
 
 declare module 'fastify-cli/helper.js' {
     module helper {
-        export function build(args: Array<string>, additionalOptions: Object, serverOptions: Object): ReturnType<typeof fastify>;
+        export function build(args: Array<string>, additionalOptions?: Object, serverOptions?: Object): ReturnType<typeof fastify>;
     }
 
     export = helper;


### PR DESCRIPTION
The third parameter of `build` is missing in the type declaration file, preventing users from passing the third parameter.

![Image](https://github.com/fastify/fastify-cli/assets/9212875/bde8250b-308f-4b83-91cf-5e06724c1b91)

This PR also renames the parameters in the doc to align with the parameter names in `helper.js`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
