### PR TITLE
fix: ensure `options` are passed to app plugin with `--options` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ module.exports = async function (fastify, options) {
 For a list of available flags for `fastify start` see the help: `fastify help start`.
 
 If you want to use custom options for the server creation, just export an options object with your route and run the cli command with the `--options` flag.
+These options also get passed to your plugin via the `options` argument.
 
 ```js
 // plugin.js
@@ -113,7 +114,8 @@ export const options = {
 }
 ```
 
-If you want to use custom options for your plugin, just add them after the `--` terminator.
+If you want to use custom options for your plugin, just add them after the `--` terminator. If used in conjunction with the `--options` argument, the CLI
+arguments take precedence.
 
 ```js
 // plugin.js

--- a/examples/plugin-with-custom-options.js
+++ b/examples/plugin-with-custom-options.js
@@ -4,3 +4,7 @@ module.exports = function (fastify, options, next) {
   fastify.get('/', (req, reply) => reply.send(options))
   next()
 }
+
+module.exports.options = {
+  hello: 'test'
+}

--- a/examples/ts-plugin-with-custom-options.js
+++ b/examples/ts-plugin-with-custom-options.js
@@ -4,3 +4,7 @@ exports.default = function (fastify, options, next) {
   fastify.get('/', (req, reply) => reply.send(options))
   next()
 }
+
+exports.options = {
+  hello: 'test'
+}

--- a/examples/ts-plugin-with-custom-options.mjs
+++ b/examples/ts-plugin-with-custom-options.mjs
@@ -6,3 +6,7 @@ export default async function plugin (fastify, options) {
     return options
   })
 }
+
+export const options = {
+  hello: 'test'
+}

--- a/start.js
+++ b/start.js
@@ -169,7 +169,7 @@ async function runFastify (args, additionalOptions, serverOptions) {
     opts.pluginOptions.prefix = opts.prefix
   }
 
-  const appConfig = Object.assign({}, opts.pluginOptions, additionalOptions)
+  const appConfig = Object.assign({}, opts.options ? file.options : {}, opts.pluginOptions, additionalOptions)
   await fastify.register(file.default || file, appConfig)
 
   const closeListeners = closeWithGrace({ delay: opts.closeGraceDelay }, async function ({ signal, err, manual }) {

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -142,6 +142,34 @@ test('should start fastify with custom plugin options', async t => {
 
   await fastify.close()
   t.pass('server closed')
+  t.end()
+})
+
+test('should start fastify with default custom plugin options', async t => {
+  t.plan(4)
+
+  const argv = [
+    '-o',
+    '-p',
+    getPort(),
+    './examples/plugin-with-custom-options.js'
+  ]
+  const fastify = await start.start(argv)
+
+  const { response, body } = await sget({
+    method: 'GET',
+    url: `http://localhost:${fastify.server.address().port}`
+  })
+
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+  t.same(JSON.parse(body), {
+    hello: 'test'
+  })
+
+  await fastify.close()
+  t.pass('server closed')
+  t.end()
 })
 
 test('should start fastify with custom options with a typescript compiled plugin', async t => {
@@ -187,6 +215,33 @@ test('should start fastify with custom plugin options with a typescript compiled
 
   await fastify.close()
   t.pass('server closed')
+})
+
+test('should start fastify with custom plugin default exported options with a typescript compiled plugin', async t => {
+  t.plan(4)
+
+  const argv = [
+    '-o',
+    '-p',
+    getPort(),
+    './examples/ts-plugin-with-custom-options.js'
+  ]
+  const fastify = await start.start(argv)
+
+  const { response, body } = await sget({
+    method: 'GET',
+    url: `http://localhost:${fastify.server.address().port}`
+  })
+
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+  t.same(JSON.parse(body), {
+    hello: 'test'
+  })
+
+  await fastify.close()
+  t.pass('server closed')
+  t.end()
 })
 
 test('should start the server at the given prefix', async t => {
@@ -965,6 +1020,33 @@ test('should start fastify with custom plugin options with a ESM typescript comp
     b: true,
     c: true,
     hello: 'world'
+  })
+
+  await fastify.close()
+  t.pass('server closed')
+  t.end()
+})
+
+test('should start fastify with custom plugin default options with a ESM typescript compiled plugin', { skip: !moduleSupport }, async t => {
+  t.plan(4)
+
+  const argv = [
+    '-o',
+    '-p',
+    getPort(),
+    './examples/ts-plugin-with-custom-options.mjs'
+  ]
+  const fastify = await start.start(argv)
+
+  const { response, body } = await sget({
+    method: 'GET',
+    url: `http://localhost:${fastify.server.address().port}`
+  })
+
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-length'], '' + body.length)
+  t.same(JSON.parse(body), {
+    hello: 'test'
   })
 
   await fastify.close()


### PR DESCRIPTION
The TS typings and docs strongly imply that the `options` object defined in the app.js file should make their way to the app plugin if the `--options` cli argument is present when running `fastify start app.js`. This fix does just that, providing the exported options object back to the app plugin when it is registered.

The CLI allows arguments to make their way to the app via additional args (coming after a `--`), eg: `fastify start app.js -l info -- --custom test` will populate the plugin `options` argument with a `custom: "test"` property. This change deliberately leaves precedence with the CLI args so that the exported `options` object just forms the default values which can then be overridden as required.

Potential fix to #593 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` ~and `npm run benchmark`~
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
