### PR TITLE
fix: should ensure can access all decorators from app built with `helper.build`

### DIFF
--- a/helper.d.ts
+++ b/helper.d.ts
@@ -1,8 +1,12 @@
 import fastify from 'fastify'
 
+type BuildOptions = {
+    skipOverride?: boolean
+}
+
 declare module 'fastify-cli/helper.js' {
     module helper {
-        export function build(args: Array<string>, additionalOptions?: Object, serverOptions?: Object): ReturnType<typeof fastify>;
+        export function build(args: Array<string>, additionalOptions?: Object, serverOptions?: Object, buildOptions?: BuildOptions): ReturnType<typeof fastify>;
     }
 
     export = helper;

--- a/helper.js
+++ b/helper.js
@@ -10,12 +10,7 @@ module.exports = {
       writable: false
     })
 
-    const buildOpts = {
-      skipOverride: true,
-      ...buildOptions
-    }
-
-    return runFastify(args, additionalOptions, serverOptions, buildOpts)
+    return runFastify(args, additionalOptions, serverOptions, buildOptions)
   },
   listen: runFastify
 }

--- a/helper.js
+++ b/helper.js
@@ -3,13 +3,19 @@
 const { runFastify } = require('./start')
 
 module.exports = {
-  build (args, additionalOptions = {}, serverOptions = {}) {
+  build (args, additionalOptions = {}, serverOptions = {}, buildOptions = {}) {
     Object.defineProperty(additionalOptions, 'ready', {
       value: true,
       enumerable: false,
       writable: false
     })
-    return runFastify(args, additionalOptions, serverOptions)
+
+    const buildOpts = {
+      skipOverride: true,
+      ...buildOptions
+    }
+
+    return runFastify(args, additionalOptions, serverOptions, buildOpts)
   },
   listen: runFastify
 }

--- a/start.js
+++ b/start.js
@@ -95,7 +95,7 @@ async function preloadESModules (opts) {
   })
 }
 
-async function runFastify (args, additionalOptions, serverOptions, buildOptions = {}) {
+async function runFastify (args, additionalOptions, serverOptions) {
   const opts = parseArgs(args)
 
   if (opts.require) {

--- a/start.js
+++ b/start.js
@@ -170,10 +170,9 @@ async function runFastify (args, additionalOptions = {}, serverOptions = {}, bui
 
   const appConfig = Object.assign({}, opts.options ? file.options : {}, opts.pluginOptions, additionalOptions)
 
-  const fn = file.default || file
-  const app = buildOptions.skipOverride ? fp(fn) : fn
-
-  await fastify.register(app, appConfig)
+  const appFn = file.default || file
+  const appPlugin = buildOptions.skipOverride ? fp(appFn) : appFn
+  await fastify.register(appPlugin, appConfig)
 
   const closeListeners = closeWithGrace({ delay: opts.closeGraceDelay }, async function ({ signal, err, manual }) {
     if (err) {

--- a/start.js
+++ b/start.js
@@ -95,7 +95,7 @@ async function preloadESModules (opts) {
   })
 }
 
-async function runFastify (args, additionalOptions = {}, serverOptions = {}, buildOptions = {}) {
+async function runFastify (args, additionalOptions, serverOptions, buildOptions = {}) {
   const opts = parseArgs(args)
 
   if (opts.require) {
@@ -156,7 +156,9 @@ async function runFastify (args, additionalOptions = {}, serverOptions = {}, bui
     }
   }
 
-  options = deepmerge(options, serverOptions)
+  if (serverOptions) {
+    options = deepmerge(options, serverOptions)
+  }
 
   if (opts.options && file.options) {
     options = deepmerge(options, file.options)
@@ -171,7 +173,7 @@ async function runFastify (args, additionalOptions = {}, serverOptions = {}, bui
   const appConfig = Object.assign({}, opts.options ? file.options : {}, opts.pluginOptions, additionalOptions)
 
   const appFn = file.default || file
-  const appPlugin = buildOptions.skipOverride ? fp(appFn) : appFn
+  const appPlugin = appConfig.skipOverride ? fp(appFn) : appFn
   await fastify.register(appPlugin, appConfig)
 
   const closeListeners = closeWithGrace({ delay: opts.closeGraceDelay }, async function ({ signal, err, manual }) {
@@ -186,7 +188,7 @@ async function runFastify (args, additionalOptions = {}, serverOptions = {}, bui
     done()
   })
 
-  if (additionalOptions.ready) {
+  if (additionalOptions && additionalOptions.ready) {
     await fastify.ready()
   } else if (opts.address) {
     await fastify.listen({ port: opts.port, host: opts.address })

--- a/templates/app-ts/test/helper.ts
+++ b/templates/app-ts/test/helper.ts
@@ -17,14 +17,13 @@ async function config () {
 
 // Automatically build and tear down our instance
 async function build (t: TestContext) {
-  // You can set all the options supported by the fastify CLI command
+  // you can set all the options supported by the fastify CLI command
   const argv = [AppPath]
 
+  // fastify-plugin ensures that all decorators
+  // are exposed for testing purposes, this is
+  // different from the production setup
   const app = await helper.build(argv, await config())
-
-  // Ensures that all decorators are exposed for testing purposes, 
-  // this is different from the production setup
-  app[Symbol.for("skip-override")] = true;
 
   // Tear down our app after we are done
   t.after(() => void app.close())

--- a/templates/app-ts/test/helper.ts
+++ b/templates/app-ts/test/helper.ts
@@ -17,13 +17,14 @@ async function config () {
 
 // Automatically build and tear down our instance
 async function build (t: TestContext) {
-  // you can set all the options supported by the fastify CLI command
+  // You can set all the options supported by the fastify CLI command
   const argv = [AppPath]
 
-  // fastify-plugin ensures that all decorators
-  // are exposed for testing purposes, this is
-  // different from the production setup
   const app = await helper.build(argv, await config())
+
+  // Ensures that all decorators are exposed for testing purposes, 
+  // this is different from the production setup
+  app[Symbol.for("skip-override")] = true;
 
   // Tear down our app after we are done
   t.after(() => void app.close())

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -153,7 +153,11 @@ test('should merge the CLI and FILE configs', async t => {
 
 test('should ensure can access all decorators', async t => {
   const argv = ['./examples/plugin.js']
-  const app = await helper.listen(argv, {})
+  const app = await helper.build(argv, { skipOverride: true })
   t.teardown(() => app.close())
   t.ok(app.test)
+
+  const app2 = await helper.listen(argv, { skipOverride: true })
+  t.teardown(() => app2.close())
+  t.ok(app2.test)
 })

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -150,3 +150,10 @@ test('should merge the CLI and FILE configs', async t => {
   t.same(lines.length, 1)
   t.same(lines[0].foo, '***')
 })
+
+test('should ensure can access all decorators', async t => {
+  const argv = ['./examples/plugin.js']
+  const app = await helper.listen(argv, {})
+  t.teardown(() => app.close())
+  t.ok(app.test)
+})


### PR DESCRIPTION
Fixes #622 