### PR TITLE
chore(templates): remove obsolete .taprc file

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ if your project uses `@fastify/swagger`, `fastify-cli` can generate and write ou
 
 "scripts": {
 + "pretest": "standard",
-  "test": "tap test/**/*.test.js",
+  "test": "node --test test/**/*.test.js",
   "start": "fastify start -l info app.js",
   "dev": "fastify start -l info -P app.js",
 + "lint": "standard --fix"
@@ -339,7 +339,7 @@ if your project uses `@fastify/swagger`, `fastify-cli` can generate and write ou
 
 When you use `fastify-cli` to run your project you need a way to load your application because you can run the CLI command.
 To do so, you can use the this module to load your application and give you the control to write your assertions.
-These utilities are async functions that you may use with the [`node-tap`](https://www.npmjs.com/package/tap) testing framework.
+These utilities are async functions that you may use with the [`Node Test runner`](https://nodejs.org/api/test.html).
 
 There are two utilities provided:
 
@@ -357,21 +357,23 @@ Both of these utilities have the `function(args, pluginOptions, serverOptions)` 
 const { build, listen } = require('fastify-cli/helper')
 
 // write a test
-const { test } = require('tap')
+const { test } = require('node:test')
+const assert = require('node:assert')
+
 test('test my application', async t => {
   const argv = ['app.js']
   const app = await build(argv, {
     extraParam: 'foo'
   })
-  t.teardown(() => app.close())
+  t.after(() => app.close())
 
   // test your application here:
   const res = await app.inject('/')
-  t.same(res.json(), { hello: 'one' })
+  assert.deepStrictEqual(res.json(), { hello: 'one' })
 })
 ```
 
-Log output is consumed by tap. If log messages should be logged to the console
+Log output is consumed by Node Test runner. If log messages should be logged to the console
 the logger needs to be configured to output to stderr instead of stdout.
 
 ```js
@@ -386,11 +388,11 @@ const logger = {
 const argv = ['app.js']
 test('test my application with logging enabled', async t => {
   const app = await build(argv, {}, { logger })
-  t.teardown(() => app.close())
+  t.after(() => app.close())
 
   // test your application here:
   const res = await app.inject('/')
-  t.same(res.json(), { hello: 'one' })
+  assert.deepStrictEqual(res.json(), { hello: 'one' })
 })
 ```
 

--- a/templates/app-ts-esm/__taprc
+++ b/templates/app-ts-esm/__taprc
@@ -1,5 +1,0 @@
-test-env: [
-  TS_NODE_FILES=true,
-  TS_NODE_PROJECT=./test/tsconfig.json
-]
-timeout: 120

--- a/templates/app-ts/__taprc
+++ b/templates/app-ts/__taprc
@@ -1,5 +1,0 @@
-test-env: [
-  TS_NODE_FILES=true,
-  TS_NODE_PROJECT=./test/tsconfig.json
-]
-timeout: 120


### PR DESCRIPTION
Hi guys,

I'm recently playing with a new project and mentioned that you migrated from `tap` to `node:assert`, but `.taprc` is still in place.
This PR just removes unnecessary `__taprc` files from templates.

Thank you! 

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
