### PR TITLE
feat: Support ESM logging module

### DIFF
--- a/start.js
+++ b/start.js
@@ -16,6 +16,7 @@ const {
   exit,
   requireModule,
   requireESModule,
+  requireModuleDefaultExport,
   requireFastifyForModule,
   requireServerPluginFromPath,
   showHelpForCommand,
@@ -120,7 +121,7 @@ async function runFastify (args, additionalOptions, serverOptions) {
   let logger
   if (opts.loggingModule) {
     try {
-      logger = requireModule(opts.loggingModule)
+      logger = await requireModuleDefaultExport(opts.loggingModule)
     } catch (e) {
       module.exports.stop(e)
     }

--- a/templates/plugin/index.d.ts
+++ b/templates/plugin/index.d.ts
@@ -7,7 +7,7 @@ declare module 'fastify' {
   }
 }
 
-declare const example: FastifyPluginCallback<() => string>
+declare const example: FastifyPluginCallback<{}>
 
 export { example }
 export default example

--- a/test/data/custom-logger.mjs
+++ b/test/data/custom-logger.mjs
@@ -1,0 +1,6 @@
+export default {
+  name: 'Custom Logger',
+  customLevels: {
+    test: 99
+  }
+}

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -947,6 +947,17 @@ test('should support custom logger configuration', async t => {
   t.pass('server closed')
 })
 
+test('should support custom logger configuration in ESM', async t => {
+  t.plan(2)
+
+  const argv = ['-L', './test/data/custom-logger.mjs', './examples/plugin.js']
+  const fastify = await start.start(argv)
+  t.ok(fastify.log.test)
+
+  await fastify.close()
+  t.pass('server closed')
+})
+
 test('preloading a built-in module works', async t => {
   t.plan(1)
 

--- a/util.js
+++ b/util.js
@@ -48,7 +48,7 @@ async function requireModuleDefaultExport (moduleName) {
     if (type === 'module') {
       return (await import(url.pathToFileURL(moduleFilePath))).default
     } else {
-      return require(moduleFilePath);
+      return require(moduleFilePath)
     }
   } else {
     return (await import(moduleName)).default

--- a/util.js
+++ b/util.js
@@ -39,6 +39,22 @@ async function requireESModule (moduleName) {
   }
 }
 
+async function requireModuleDefaultExport (moduleName) {
+  if (fs.existsSync(moduleName)) {
+    const packageType = await getPackageType(path.dirname(moduleName))
+    const type = getScriptType(moduleName, packageType)
+
+    const moduleFilePath = path.resolve(moduleName)
+    if (type === 'module') {
+      return (await import(url.pathToFileURL(moduleFilePath))).default
+    } else {
+      return require(moduleFilePath);
+    }
+  } else {
+    return (await import(moduleName)).default
+  }
+}
+
 function requireFastifyForModule (modulePath) {
   try {
     const basedir = path.resolve(process.cwd(), modulePath)
@@ -118,6 +134,7 @@ module.exports = {
   exit,
   requireModule,
   requireESModule,
+  requireModuleDefaultExport,
   requireFastifyForModule,
   showHelpForCommand,
   requireServerPluginFromPath


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Fixes #760 

~~I also want to add support for taking the logger from the main plugin module instead, in the same way you can specify an options object as a named export on it when giving the `--options` flag. But I haven't decided on how to name the CLI flag and if it should have a short single letter alias. Any suggestions?~~ &ndash; This already exists as `options.logger` with `--options` enabled. But there is an issue with `deepmerge` and passing an already created `pino.Logger`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
