### PR TITLE
refactor: generate test build function configured with skipOverride

### DIFF
--- a/templates/app-esm/test/helper.js
+++ b/templates/app-esm/test/helper.js
@@ -12,7 +12,9 @@ const AppPath = path.join(__dirname, '..', 'app.js')
 // Fill in this config with all the configurations
 // needed for testing the application
 function config () {
-  return {}
+  return {
+    skipOverride: true // Register our application with fastify-plugin
+  }
 }
 
 // automatically build and tear down our instance

--- a/templates/app-ts-esm/test/helper.ts
+++ b/templates/app-ts-esm/test/helper.ts
@@ -14,7 +14,7 @@ const AppPath = path.join(__dirname, '..', 'src', 'app.ts')
 
 // Fill in this config with all the configurations
 // needed for testing the application
-async function config () {
+function config () {
   return {
     skipOverride: true // Register our application with fastify-plugin
   }
@@ -28,7 +28,7 @@ async function build (t: TestContext) {
   // fastify-plugin ensures that all decorators
   // are exposed for testing purposes, this is
   // different from the production setup
-  const app = await helper.build(argv, await config())
+  const app = await helper.build(argv, config())
 
   // Tear down our app after we are done
   t.after(() => void app.close())

--- a/templates/app-ts-esm/test/helper.ts
+++ b/templates/app-ts-esm/test/helper.ts
@@ -15,7 +15,9 @@ const AppPath = path.join(__dirname, '..', 'src', 'app.ts')
 // Fill in this config with all the configurations
 // needed for testing the application
 async function config () {
-  return {}
+  return {
+    skipOverride: true // Register our application with fastify-plugin
+  }
 }
 
 // Automatically build and tear down our instance

--- a/templates/app-ts/test/helper.ts
+++ b/templates/app-ts/test/helper.ts
@@ -11,7 +11,7 @@ const AppPath = path.join(__dirname, '..', 'src', 'app.ts')
 
 // Fill in this config with all the configurations
 // needed for testing the application
-async function config () {
+function config () {
   return {
     skipOverride: true // Register our application with fastify-plugin
   }
@@ -25,7 +25,7 @@ async function build (t: TestContext) {
   // fastify-plugin ensures that all decorators
   // are exposed for testing purposes, this is
   // different from the production setup
-  const app = await helper.build(argv, await config())
+  const app = await helper.build(argv, config())
 
   // Tear down our app after we are done
   t.after(() => void app.close())

--- a/templates/app-ts/test/helper.ts
+++ b/templates/app-ts/test/helper.ts
@@ -12,7 +12,9 @@ const AppPath = path.join(__dirname, '..', 'src', 'app.ts')
 // Fill in this config with all the configurations
 // needed for testing the application
 async function config () {
-  return {}
+  return {
+    skipOverride: true // Register our application with fastify-plugin
+  }
 }
 
 // Automatically build and tear down our instance

--- a/templates/app/test/helper.js
+++ b/templates/app/test/helper.js
@@ -10,7 +10,9 @@ const AppPath = path.join(__dirname, '..', 'app.js')
 // Fill in this config with all the configurations
 // needed for testing the application
 function config () {
-  return {}
+  return {
+    skipOverride: true // Register our application with fastify-plugin
+  }
 }
 
 // automatically build and tear down our instance


### PR DESCRIPTION
I think that users expect to have access decorators defined globally in their tests.
Currently we generate the test application without wrapping it in `fastify-plugin` which  causes confusions (c.f. [here](https://github.com/fastify/fastify-cli/issues/622), [here](https://github.com/fastify/fastify-cli/issues/628) and [here](https://github.com/fastify/fastify-cli/issues/781)).