### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/templates/app-esm/app.js
+++ b/templates/app-esm/app.js
@@ -1,6 +1,6 @@
-import path from 'path'
+import path from 'node:path'
 import AutoLoad from '@fastify/autoload'
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)

--- a/templates/app-esm/test/helper.js
+++ b/templates/app-esm/test/helper.js
@@ -2,8 +2,8 @@
 // between our tests.
 
 import helper from 'fastify-cli/helper.js'
-import path from 'path'
-import { fileURLToPath } from 'url'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)

--- a/templates/app-ts-esm/src/app.ts
+++ b/templates/app-ts-esm/src/app.ts
@@ -1,7 +1,7 @@
-import * as path from 'path';
+import * as path from 'node:path';
 import AutoLoad, {AutoloadPluginOptions} from '@fastify/autoload';
 import { FastifyPluginAsync } from 'fastify';
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)

--- a/templates/app-ts-esm/test/helper.ts
+++ b/templates/app-ts-esm/test/helper.ts
@@ -1,8 +1,8 @@
 // This file contains code that we reuse between our tests.
 import helper from 'fastify-cli/helper.js'
 import * as test from 'node:test'
-import * as path from 'path'
-import { fileURLToPath } from 'url'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 export type TestContext = {
   after: typeof test.after

--- a/templates/app-ts/src/app.ts
+++ b/templates/app-ts/src/app.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import AutoLoad, {AutoloadPluginOptions} from '@fastify/autoload';
 import { FastifyPluginAsync, FastifyServerOptions } from 'fastify';
 

--- a/templates/app-ts/test/helper.ts
+++ b/templates/app-ts/test/helper.ts
@@ -1,6 +1,6 @@
 // This file contains code that we reuse between our tests.
 const helper = require('fastify-cli/helper.js')
-import * as path from 'path'
+import * as path from 'node:path'
 import * as test from 'node:test'
 
 export type TestContext = {

--- a/test/esm/util.test.js
+++ b/test/esm/util.test.js
@@ -1,7 +1,7 @@
 import { requireModule } from '../../util.js'
 import { resolve, join } from 'node:path'
 import t from 'tap'
-import * as url from 'url'
+import * as url from 'node:url'
 
 const test = t.test
 


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407. This is a batch PR, so may have some issues. Please review changes.