### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "c8": "^10.1.2",
     "concurrently": "^9.0.0",
     "cross-env": "^7.0.3",
+    "eslint": "^9.17.0",
     "fastify-tsconfig": "^2.0.0",
     "minimatch": "^9.0.5",
     "proxyquire": "^2.1.3",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.