### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/test/templates/app-ts.test.ts
+++ b/test/templates/app-ts.test.ts
@@ -1,7 +1,7 @@
 import { fastify } from 'fastify'
 import { test, TestContext } from 'node:test'
 
-import { AddressInfo } from 'net'
+import { AddressInfo } from 'node:net'
 import appDefault, { app } from '../../templates/app-ts/src/app'
 const sgetOriginal = require('simple-get').concat
 


### PR DESCRIPTION
This is a batch PR, so may have some issues. Please review changes.