### PR TITLE
ci(.github): use latest node version

### DIFF
--- a/templates/plugin/.github/workflows/ci.yml
+++ b/templates/plugin/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
+        check-latest: true
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
       run: npm install --ignore-scripts


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5577. This is a batch PR, so may have some issues. Please review changes.