### PR TITLE
fix: correct fastify version on plugin genration

### DIFF
--- a/templates/plugin/index.js
+++ b/templates/plugin/index.js
@@ -6,4 +6,4 @@ module.exports = fp(async function (fastify, opts) {
   fastify.decorate('exampleDecorator', () => {
     return 'decorated'
   })
-}, { fastify: '^4.x' })
+}, { fastify: '^5.x' })

--- a/test/generate-plugin.test.js
+++ b/test/generate-plugin.test.js
@@ -100,15 +100,34 @@ function define (t) {
   })
 
   test('should finish succesfully', async (t) => {
-    t.plan(17 + Object.keys(expected).length)
+    t.plan(18 + Object.keys(expected).length)
     try {
       await generate(workdir, pluginTemplate)
       await verifyPkg(t)
       await verifyCopy(t, expected)
+      await verifyFastifyPluginVersion(t)
     } catch (err) {
       t.error(err)
     }
   })
+
+  function verifyFastifyPluginVersion (t) {
+    return new Promise((resolve, reject) => {
+      const pkgFile = path.join(workdir, 'package.json')
+
+      readFile(pkgFile, function (err, data) {
+        err && reject(err)
+        const pkg = JSON.parse(data)
+        const indexFilePath = path.join(workdir, 'index.js')
+        const indexFile = readFileSync(indexFilePath)
+        const version = pkg.dependencies['fastify-plugin']
+        const majorToMatch = version.split('.')[0]
+        const foundCorrectFastifyVersion = indexFile.toString().indexOf(`fastify: '${majorToMatch}.x'`) >= 0
+        t.equal(foundCorrectFastifyVersion, true)
+        resolve()
+      })
+    })
+  }
 
   function verifyPkg (t) {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
This PR aims to fix the error that occurs when using the generate-plugin command, which copies the template with version ^4.0 instead of ^5.0.0
I've already opened an issue: #803 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [v] run `npm run test` and `npm run benchmark`
- [v] tests and/or benchmarks are included
- [v] documentation is changed or added
- [v] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

[![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://lu.ma/open-source-saturday-torino)