### PR TITLE
ci(ci): remove auto merge exclude

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,3 @@ jobs:
     uses: fastify/workflows/.github/workflows/plugins-ci.yml@v5
     with:
       lint: true
-      auto-merge-exclude: 'help-me'


### PR DESCRIPTION
This fixes a minor issue where help-me was excluded in merging. Looking at the previous issues, it seems that everything is fixed and we should be good in upgrading to 5.x. Also helps in fixing security vulnerabilities reported by snyk.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
