### PR TITLE
ci: set permissions at workflow level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ on:
       - 'docs/**'
       - '*.md'
 
+permissions:
+  contents: read
+
 jobs:
   test:
-    permissions:
-      contents: write
-      pull-requests: write
     uses: fastify/workflows/.github/workflows/plugins-ci.yml@v5
     with:
       lint: true


### PR DESCRIPTION
This is a batch PR. This change stops security tools like step-security from complaining.