### PR TITLE
Pass an already imported module in helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,11 +349,12 @@ There are two utilities provided:
 - `build`: builds your application and returns the `fastify` instance without calling the `listen` method.
 - `listen`: starts your application and returns the `fastify` instance listening on the configured port.
 
-Both of these utilities have the `function(args, pluginOptions, serverOptions)` parameters:
+Both of these utilities have the `function(args, pluginOptions, serverOptions, serverModule)` parameters:
 
 - `args`: is a string or a string array within the same arguments passed to the `fastify-cli` command.
 - `pluginOptions`: is an object containing the options provided to the started plugin (eg: `app.js`).
 - `serverOptions`: is an object containing the additional options provided to fastify server, similar to the `--options` command line argument
+- `serverModule`: is optionally the the already imported main server plugin module, instead of letting the helper import it.
 
 ```js
 // load the utility helper functions

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ Both of these utilities have the `function(args, pluginOptions, serverOptions, s
 - `args`: is a string or a string array within the same arguments passed to the `fastify-cli` command.
 - `pluginOptions`: is an object containing the options provided to the started plugin (eg: `app.js`).
 - `serverOptions`: is an object containing the additional options provided to fastify server, similar to the `--options` command line argument
-- `serverModule`: is optionally the the already imported main server plugin module, instead of letting the helper import it.
+- `serverModule`: is an optional parameter used to provide the already imported main server plugin module, instead of letting the helper import it.
 
 ```js
 // load the utility helper functions

--- a/helper.d.ts
+++ b/helper.d.ts
@@ -1,8 +1,9 @@
 import fastify from 'fastify'
 
 declare module 'fastify-cli/helper.js' {
-  module helper {
+  namespace helper {
     export function build (args: Array<string>, additionalOptions?: Object, serverOptions?: Object, serverModule?: Object): ReturnType<typeof fastify>
+    export function listen (args: Array<string>, additionalOptions?: Object, serverOptions?: Object, serverModule?: Object): ReturnType<typeof fastify>
   }
 
   export = helper

--- a/helper.d.ts
+++ b/helper.d.ts
@@ -2,7 +2,7 @@ import fastify from 'fastify'
 
 declare module 'fastify-cli/helper.js' {
   module helper {
-    export function build (args: Array<string>, additionalOptions?: Object, serverOptions?: Object, module?: Object): ReturnType<typeof fastify>
+    export function build (args: Array<string>, additionalOptions?: Object, serverOptions?: Object, serverModule?: Object): ReturnType<typeof fastify>
   }
 
   export = helper

--- a/helper.d.ts
+++ b/helper.d.ts
@@ -2,7 +2,7 @@ import fastify from 'fastify'
 
 declare module 'fastify-cli/helper.js' {
   module helper {
-    export function build (args: Array<string>, additionalOptions?: Object, serverOptions?: Object): ReturnType<typeof fastify>
+    export function build (args: Array<string>, additionalOptions?: Object, serverOptions?: Object, module?: Object): ReturnType<typeof fastify>
   }
 
   export = helper

--- a/helper.js
+++ b/helper.js
@@ -3,14 +3,14 @@
 const { runFastify } = require('./start')
 
 module.exports = {
-  build (args, additionalOptions = {}, serverOptions = {}) {
+  build (args, additionalOptions = {}, serverOptions = {}, module = undefined) {
     Object.defineProperty(additionalOptions, 'ready', {
       value: true,
       enumerable: false,
       writable: false
     })
 
-    return runFastify(args, additionalOptions, serverOptions)
+    return runFastify(args, additionalOptions, serverOptions, module)
   },
   listen: runFastify
 }

--- a/helper.js
+++ b/helper.js
@@ -3,14 +3,14 @@
 const { runFastify } = require('./start')
 
 module.exports = {
-  build (args, additionalOptions = {}, serverOptions = {}, module = undefined) {
+  build (args, additionalOptions = {}, serverOptions = {}, serverModule = undefined) {
     Object.defineProperty(additionalOptions, 'ready', {
       value: true,
       enumerable: false,
       writable: false
     })
 
-    return runFastify(args, additionalOptions, serverOptions, module)
+    return runFastify(args, additionalOptions, serverOptions, serverModule)
   },
   listen: runFastify
 }

--- a/start.js
+++ b/start.js
@@ -96,7 +96,7 @@ async function preloadESModules (opts) {
   })
 }
 
-async function runFastify (args, additionalOptions, serverOptions, module) {
+async function runFastify (args, additionalOptions, serverOptions, serverModule) {
   const opts = parseArgs(args)
 
   if (opts.require) {
@@ -113,8 +113,8 @@ async function runFastify (args, additionalOptions, serverOptions, module) {
   let file = null
 
   try {
-    if (module != null) {
-      file = module
+    if (serverModule != null) {
+      file = serverModule
     } else {
       file = await requireServerPluginFromPath(opts._[0])
     }

--- a/start.js
+++ b/start.js
@@ -96,7 +96,7 @@ async function preloadESModules (opts) {
   })
 }
 
-async function runFastify (args, additionalOptions, serverOptions) {
+async function runFastify (args, additionalOptions, serverOptions, module) {
   const opts = parseArgs(args)
 
   if (opts.require) {
@@ -113,7 +113,11 @@ async function runFastify (args, additionalOptions, serverOptions) {
   let file = null
 
   try {
-    file = await requireServerPluginFromPath(opts._[0])
+    if (module != null) {
+      file = module
+    } else {
+      file = await requireServerPluginFromPath(opts._[0])
+    }
   } catch (e) {
     return module.exports.stop(e)
   }

--- a/start.js
+++ b/start.js
@@ -113,11 +113,7 @@ async function runFastify (args, additionalOptions, serverOptions, serverModule)
   let file = null
 
   try {
-    if (serverModule != null) {
-      file = serverModule
-    } else {
-      file = await requireServerPluginFromPath(opts._[0])
-    }
+    file = serverModule ?? await requireServerPluginFromPath(opts._[0])
   } catch (e) {
     return module.exports.stop(e)
   }

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -164,7 +164,10 @@ test('should ensure can access all decorators', async t => {
 
 test('should return the fastify instance when using serverModule', async t => {
   const argv = ['']
-  const app = await helper.build(argv, {}, {}, require('../examples/plugin.js'))
+  const app = await helper.build(argv, { skipOverride: true }, {}, (app, opts, next) => {
+    app.decorate('foo', 'bar')
+    next()
+  })
   t.teardown(() => app.close())
-  t.notOk(app.server.listening)
+  t.equals(app.foo, 'bar')
 })

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -161,3 +161,10 @@ test('should ensure can access all decorators', async t => {
   t.teardown(() => app2.close())
   t.ok(app2.test)
 })
+
+test('should return the fastify instance when using serverModule', async t => {
+  const argv = ['']
+  const app = await helper.build(argv, {}, {}, require('../examples/plugin.js'))
+  t.teardown(() => app.close())
+  t.notOk(app.server.listening)
+})


### PR DESCRIPTION
This is useful when running in environment that
transpile on the fly, such as Jest/Vitest and so
on, which don't handle the dynamic import all that
well.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
