### PR TITLE
test: migrated eject test from tap to node:test

### DIFF
--- a/test/eject-esm.test.js
+++ b/test/eject-esm.test.js
@@ -1,10 +1,7 @@
 'use strict'
 
-// bailout if a test is broken
-// so that the folder can be inspected
-process.env.TAP_BAIL = true
-
-const t = require('tap')
+const { test } = require('node:test')
+const assert = require('node:assert')
 const {
   mkdirSync,
   readFileSync,
@@ -45,8 +42,8 @@ const expected = {};
     })
     .on('error', cb)
 })(function (err) {
-  t.error(err)
-  define(t)
+  assert.ifError(err)
+  define(test)
 })
 
 function define (t) {
@@ -63,7 +60,7 @@ function define (t) {
       await eject(workdir, template)
       await verifyCopy(t, expected)
     } catch (err) {
-      t.error(err)
+      t.assert.ifError(err)
     }
   })
 
@@ -73,7 +70,7 @@ function define (t) {
       await cli(['--esm'])
       await verifyCopy(t, expected)
     } catch (err) {
-      t.error(err)
+      t.assert.ifError(err)
     }
   })
 
@@ -86,7 +83,7 @@ function define (t) {
           try {
             const data = readFileSync(file)
             file = file.replace(workdir, '')
-            t.same(
+            t.assert.deepStrictEqual(
               data.toString().replace(/\r\n/g, '\n'),
               expected[file],
               file + ' matching'
@@ -96,7 +93,7 @@ function define (t) {
           }
         })
         .on('end', function () {
-          t.equal(Object.keys(expected).length, count)
+          t.assert.strictEqual(Object.keys(expected).length, count)
           resolve()
         })
         .on('error', function (err, entry, stat) {

--- a/test/eject-ts.test.js
+++ b/test/eject-ts.test.js
@@ -1,10 +1,7 @@
 'use strict'
 
-// bailout if a test is broken
-// so that the folder can be inspected
-process.env.TAP_BAIL = true
-
-const t = require('tap')
+const { test } = require('node:test')
+const assert = require('node:assert')
 const { mkdirSync, readFileSync, readFile } = require('node:fs')
 const path = require('node:path')
 const rimraf = require('rimraf')
@@ -41,8 +38,8 @@ const expected = {};
     })
     .on('error', cb)
 })(function (err) {
-  t.error(err)
-  define(t)
+  assert.ifError(err)
+  define(test)
 })
 
 function define (t) {
@@ -59,7 +56,7 @@ function define (t) {
       await eject(workdir, template)
       await verifyCopy(t, expected)
     } catch (err) {
-      t.error(err)
+      t.assert.ifError(err)
     }
   })
 
@@ -69,7 +66,7 @@ function define (t) {
       await cli(['--lang=typescript'])
       await verifyCopy(t, expected)
     } catch (err) {
-      t.error(err)
+      t.assert.ifError(err)
     }
   })
 
@@ -82,7 +79,7 @@ function define (t) {
           try {
             const data = readFileSync(file)
             file = file.replace(workdir, '')
-            t.same(
+            t.assert.deepStrictEqual(
               data.toString().replace(/\r\n/g, '\n'),
               expected[file],
               file + ' matching'
@@ -92,7 +89,7 @@ function define (t) {
           }
         })
         .on('end', function () {
-          t.equal(Object.keys(expected).length, count)
+          t.assert.strictEqual(Object.keys(expected).length, count)
           resolve()
         })
         .on('error', function (err, entry, stat) {

--- a/test/eject.test.js
+++ b/test/eject.test.js
@@ -1,10 +1,7 @@
 'use strict'
 
-// bailout if a test is broken
-// so that the folder can be inspected
-process.env.TAP_BAIL = true
-
-const t = require('tap')
+const { test } = require('node:test')
+const assert = require('node:assert')
 const {
   mkdirSync,
   readFileSync,
@@ -43,8 +40,8 @@ const expected = {}
     })
     .on('error', cb)
 })(function (err) {
-  t.error(err)
-  define(t)
+  assert.ifError(err)
+  define(test)
 })
 
 function define (t) {
@@ -61,7 +58,7 @@ function define (t) {
       await eject(workdir, template)
       await verifyCopy(t, expected)
     } catch (err) {
-      t.error(err)
+      t.assert.ifError(err)
     }
   })
 
@@ -71,7 +68,7 @@ function define (t) {
       await cli([])
       await verifyCopy(t, expected)
     } catch (err) {
-      t.error(err)
+      t.assert.ifError(err)
     }
   })
 
@@ -84,13 +81,13 @@ function define (t) {
           try {
             const data = readFileSync(file)
             file = file.replace(workdir, '')
-            t.same(data.toString().replace(/\r\n/g, '\n'), expected[file], file + ' matching')
+            t.assert.deepStrictEqual(data.toString().replace(/\r\n/g, '\n'), expected[file], file + ' matching')
           } catch (err) {
             reject(err)
           }
         })
         .on('end', function () {
-          t.equal(Object.keys(expected).length, count)
+          t.assert.strictEqual(Object.keys(expected).length, count)
           resolve()
         })
         .on('error', function (err, entry, stat) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)


Proposals:

- migrated `eject-esm.test.js` from `tap` to `node:test` 🔥
- migrated `eject-ts.test.js` from `tap` to `node:test` 🔥
- migrated `eject.test.js` from `tap` to `node:test` 🔥

