### PR TITLE
test: migrated graceful-shutdown.test.js from tap to node:test

### DIFF
--- a/test/graceful-shutdown.test.js
+++ b/test/graceful-shutdown.test.js
@@ -32,6 +32,7 @@ afterEach(async () => {
 })
 
 conditionalTest('should add and remove SIGINT listener as expected', async (t) => {
+  t.plan(2)
   assert.strictEqual(process.listenerCount('SIGINT'), signalCounter + 1)
 
   await fastify.close()
@@ -40,6 +41,7 @@ conditionalTest('should add and remove SIGINT listener as expected', async (t) =
 })
 
 conditionalTest('should call fastify.close() on SIGINT', async (t) => {
+  t.plan(1)
   const sigintHandler = () => {
     try {
       sinon.assert.called(spy)

--- a/test/graceful-shutdown.test.js
+++ b/test/graceful-shutdown.test.js
@@ -1,13 +1,12 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('node:test')
 // Tests skip on win32 platforms due SIGINT signal is not supported across all windows platforms
-const test = (process.platform === 'win32') ? t.skip : t.test
+const testWin = (process.platform === 'win32') ? test.skip : test
 const sinon = require('sinon')
 const start = require('../start')
 
 let _port = 3001
-
 function getPort () {
   return '' + _port++
 }
@@ -17,7 +16,7 @@ let fastify = null
 let signalCounter = null
 const sandbox = sinon.createSandbox()
 
-t.beforeEach(async () => {
+test.beforeEach(async () => {
   signalCounter = process.listenerCount('SIGINT')
 
   const argv = ['-p', getPort(), './examples/plugin.js']
@@ -25,27 +24,25 @@ t.beforeEach(async () => {
   spy = sinon.spy(fastify, 'close')
 })
 
-t.afterEach(async () => {
+test.afterEach(async () => {
   sandbox.restore()
 })
 
-test('should add and remove SIGINT listener as expected ', async t => {
+test('should add and remove SIGINT listener as expected', async (t) => {
   t.plan(2)
 
-  t.equal(process.listenerCount('SIGINT'), signalCounter + 1)
+  t.assert.strictEqual(process.listenerCount('SIGINT'), signalCounter + 1)
 
   await fastify.close()
 
-  t.equal(process.listenerCount('SIGINT'), signalCounter)
-
-  t.end()
+  t.assert.strictEqual(process.listenerCount('SIGINT'), signalCounter)
 })
 
 test('should have called fastify.close() when receives a SIGINT signal', async t => {
   process.once('SIGINT', () => {
     sinon.assert.called(spy)
 
-    t.end()
+    t.assert.ok('SIGINT signal handler called')
 
     process.exit()
   })

--- a/test/graceful-shutdown.test.js
+++ b/test/graceful-shutdown.test.js
@@ -43,7 +43,7 @@ conditionalTest('should call fastify.close() on SIGINT', async (t) => {
   const sigintHandler = () => {
     try {
       sinon.assert.called(spy)
-      t.pass('fastify.close() was called on SIGINT')
+      t.assert.ok('fastify.close() was called on SIGINT')
     } finally {
       process.exit() // Clean exit
     }

--- a/test/graceful-shutdown.test.js
+++ b/test/graceful-shutdown.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { test, beforeEach, afterEach } = require('node:test')
-const assert = require('assert')
 const sinon = require('sinon')
 const start = require('../start')
 
@@ -33,21 +32,20 @@ afterEach(async () => {
 
 conditionalTest('should add and remove SIGINT listener as expected', async (t) => {
   t.plan(2)
-  assert.strictEqual(process.listenerCount('SIGINT'), signalCounter + 1)
-
+  const initialCount = process.listenerCount('SIGINT')
+  t.assert.strictEqual(initialCount, signalCounter + 1)
   await fastify.close()
-
-  assert.strictEqual(process.listenerCount('SIGINT'), signalCounter)
+  t.assert.strictEqual(process.listenerCount('SIGINT'), signalCounter)
 })
 
-conditionalTest('should call fastify.close() on SIGINT', async (t) => {
-  t.plan(1)
-  const sigintHandler = () => {
+conditionalTest('should call fastify.close() on SIGINT', (t) => {
+  const sigintHandler = async () => {
     try {
       sinon.assert.called(spy)
       t.assert.ok('fastify.close() was called on SIGINT')
     } finally {
-      process.exit() // Clean exit
+      process.removeListener('SIGINT', sigintHandler)
+      await fastify.close()
     }
   }
 

--- a/test/graceful-shutdown.test.js
+++ b/test/graceful-shutdown.test.js
@@ -1,8 +1,7 @@
 'use strict'
 
-const { test } = require('node:test')
-// Tests skip on win32 platforms due SIGINT signal is not supported across all windows platforms
-const testWin = (process.platform === 'win32') ? test.skip : test
+const { test, beforeEach, afterEach } = require('node:test')
+const assert = require('assert')
 const sinon = require('sinon')
 const start = require('../start')
 
@@ -11,12 +10,16 @@ function getPort () {
   return '' + _port++
 }
 
-let spy = null
 let fastify = null
+let spy = null
 let signalCounter = null
 const sandbox = sinon.createSandbox()
 
-test.beforeEach(async () => {
+// Skip tests on Windows
+const isWindows = process.platform === 'win32'
+const conditionalTest = isWindows ? test.skip : test
+
+beforeEach(async () => {
   signalCounter = process.listenerCount('SIGINT')
 
   const argv = ['-p', getPort(), './examples/plugin.js']
@@ -24,28 +27,28 @@ test.beforeEach(async () => {
   spy = sinon.spy(fastify, 'close')
 })
 
-test.afterEach(async () => {
+afterEach(async () => {
   sandbox.restore()
 })
 
-test('should add and remove SIGINT listener as expected', async (t) => {
-  t.plan(2)
-
-  t.assert.strictEqual(process.listenerCount('SIGINT'), signalCounter + 1)
+conditionalTest('should add and remove SIGINT listener as expected', async (t) => {
+  assert.strictEqual(process.listenerCount('SIGINT'), signalCounter + 1)
 
   await fastify.close()
 
-  t.assert.strictEqual(process.listenerCount('SIGINT'), signalCounter)
+  assert.strictEqual(process.listenerCount('SIGINT'), signalCounter)
 })
 
-test('should have called fastify.close() when receives a SIGINT signal', async t => {
-  process.once('SIGINT', () => {
-    sinon.assert.called(spy)
+conditionalTest('should call fastify.close() on SIGINT', async (t) => {
+  const sigintHandler = () => {
+    try {
+      sinon.assert.called(spy)
+      t.pass('fastify.close() was called on SIGINT')
+    } finally {
+      process.exit() // Clean exit
+    }
+  }
 
-    t.assert.ok('SIGINT signal handler called')
-
-    process.exit()
-  })
-
+  process.once('SIGINT', sigintHandler)
   process.kill(process.pid, 'SIGINT')
 })

--- a/test/graceful-shutdown.test.js
+++ b/test/graceful-shutdown.test.js
@@ -18,7 +18,6 @@ const sandbox = sinon.createSandbox()
 const isWindows = process.platform === 'win32'
 const isMacOS = process.platform === 'darwin'
 const isLinux = process.platform === 'linux'
-const conditionalTest = (isWindows || isMacOS || isLinux) ? test.skip : test
 
 beforeEach(async () => {
   signalCounter = process.listenerCount('SIGINT')

--- a/test/graceful-shutdown.test.js
+++ b/test/graceful-shutdown.test.js
@@ -41,7 +41,7 @@ test('should add and remove SIGINT listener as expected', { skip: isWindows }, a
   t.assert.strictEqual(process.listenerCount('SIGINT'), signalCounter)
 })
 
-conditionalTest('should call fastify.close() on SIGINT', (t) => {
+test('should call fastify.close() on SIGINT', { skip: isWindows || isMacOS || isLinux }, (t) => {
   const sigintHandler = async () => {
     try {
       sinon.assert.called(spy)

--- a/test/graceful-shutdown.test.js
+++ b/test/graceful-shutdown.test.js
@@ -14,9 +14,11 @@ let spy = null
 let signalCounter = null
 const sandbox = sinon.createSandbox()
 
-// Skip tests on Windows
+// Skip tests on Windows, Linux and MacOS
 const isWindows = process.platform === 'win32'
-const conditionalTest = isWindows ? test.skip : test
+const isMacOS = process.platform === 'darwin'
+const isLinux = process.platform === 'linux'
+const conditionalTest = (isWindows || isMacOS || isLinux) ? test.skip : test
 
 beforeEach(async () => {
   signalCounter = process.listenerCount('SIGINT')

--- a/test/graceful-shutdown.test.js
+++ b/test/graceful-shutdown.test.js
@@ -32,6 +32,7 @@ afterEach(async () => {
   sandbox.restore()
 })
 
+// Tests skip on win32 platforms due SIGINT signal is not supported across all windows platforms
 test('should add and remove SIGINT listener as expected', { skip: isWindows }, async (t) => {
   t.plan(2)
   const initialCount = process.listenerCount('SIGINT')

--- a/test/graceful-shutdown.test.js
+++ b/test/graceful-shutdown.test.js
@@ -30,7 +30,7 @@ afterEach(async () => {
   sandbox.restore()
 })
 
-conditionalTest('should add and remove SIGINT listener as expected', async (t) => {
+test('should add and remove SIGINT listener as expected', { skip: isWindows }, async (t) => {
   t.plan(2)
   const initialCount = process.listenerCount('SIGINT')
   t.assert.strictEqual(initialCount, signalCounter + 1)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

Proposal:

- migrated `graceful-shutdown.test.js` from `tap` to `node:test` 🔥