### PR TITLE
ci: use tags for immutable github actions

### DIFF
--- a/templates/plugin/.github/workflows/ci.yml
+++ b/templates/plugin/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
         node-version: [20, 22, 24]
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/checkout@v4
       with:
         persist-credentials: false
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@v4
       with:
         check-latest: true
         node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
Most first party actions now use https://github.com/actions/publish-immutable-action, which negates the need for commit hashes