### PR TITLE
test: migrated print-plugins.test.js to tap to node:test

### DIFF
--- a/test/print-plugins.test.js
+++ b/test/print-plugins.test.js
@@ -1,14 +1,12 @@
 'use strict'
 
 const proxyquire = require('proxyquire')
-const tap = require('tap')
+const { test } = require('node:test')
 const sinon = require('sinon')
 const util = require('node:util')
 const exec = util.promisify(require('node:child_process').exec)
 
 const printPlugins = require('../print-plugins')
-
-const test = tap.test
 
 const { NYC_PROCESS_ID, NODE_V8_COVERAGE } = process.env
 const SHOULD_SKIP = NYC_PROCESS_ID || NODE_V8_COVERAGE
@@ -24,54 +22,57 @@ test('should print plugins', { skip: SHOULD_SKIP }, async t => {
   const fastify = await command.printPlugins(['./examples/plugin.js'])
 
   await fastify.close()
-  t.ok(spy.called)
-  t.same(spy.args[0][0], 'debug')
-  t.match(spy.args[0][1], /bound root \d+ ms\n├── bound _after \d+ ms\n├─┬ function \(fastify, options, next\) { -- fastify\.decorate\('test', true\) \d+ ms\n│ ├── bound _after \d+ ms\n│ ├── bound _after \d+ ms\n│ └── bound _after \d+ ms\n└── bound _after \d+ ms\n/)
+  t.assert.ok(spy.called)
+  t.assert.deepStrictEqual(spy.args[0][0], 'debug')
+  t.assert.match(spy.args[0][1], /root \d+ ms\n├── bound _after \d+ ms\n├─┬ function \(fastify, options, next\) { -- fastify\.decorate\('test', true\) \d+ ms\n│ ├── bound _after \d+ ms\n│ ├── bound _after \d+ ms\n│ └── bound _after \d+ ms\n└── bound _after \d+ ms\n/)
 })
 
 // This test should be skipped when coverage reporting is used since outputs won't match
 test('should plugins routes via cli', { skip: SHOULD_SKIP }, async t => {
   t.plan(1)
   const { stdout } = await exec('node cli.js print-plugins ./examples/plugin.js', { encoding: 'utf-8', timeout: 10000 })
-  t.match(
+  t.assert.match(
     stdout,
-    /bound root \d+ ms\n├── bound _after \d+ ms\n├─┬ function \(fastify, options, next\) { -- fastify\.decorate\('test', true\) \d+ ms\n│ ├── bound _after \d+ ms\n│ ├── bound _after \d+ ms\n│ └── bound _after \d+ ms\n└── bound _after \d+ ms\n\n/
+    /root \d+ ms\n├── bound _after \d+ ms\n├─┬ function \(fastify, options, next\) { -- fastify\.decorate\('test', true\) \d+ ms\n│ ├── bound _after \d+ ms\n│ ├── bound _after \d+ ms\n│ └── bound _after \d+ ms\n└── bound _after \d+ ms\n\n/
   )
 })
 
-test('should warn on file not found', t => {
+test('should warn on file not found', (t, done) => {
   t.plan(1)
 
   const oldStop = printPlugins.stop
-  t.teardown(() => { printPlugins.stop = oldStop })
+  t.after(() => { printPlugins.stop = oldStop })
   printPlugins.stop = function (message) {
-    t.ok(/not-found.js doesn't exist within/.test(message), message)
+    t.assert.ok(/not-found.js doesn't exist within/.test(message), message)
+    done()
   }
 
   const argv = ['./data/not-found.js']
   printPlugins.printPlugins(argv)
 })
 
-test('should throw on package not found', t => {
+test('should throw on package not found', (t, done) => {
   t.plan(1)
 
   const oldStop = printPlugins.stop
-  t.teardown(() => { printPlugins.stop = oldStop })
+  t.after(() => { printPlugins.stop = oldStop })
   printPlugins.stop = function (err) {
-    t.ok(/Cannot find module 'unknown-package'/.test(err.message), err.message)
+    t.assert.ok(/Cannot find module 'unknown-package'/.test(err.message), err.message)
+    done()
   }
 
   const argv = ['./test/data/package-not-found.js']
   printPlugins.printPlugins(argv)
 })
 
-test('should throw on parsing error', t => {
+test('should throw on parsing error', (t, done) => {
   t.plan(1)
 
   const oldStop = printPlugins.stop
-  t.teardown(() => { printPlugins.stop = oldStop })
+  t.after(() => { printPlugins.stop = oldStop })
   printPlugins.stop = function (err) {
-    t.equal(err.constructor, SyntaxError)
+    t.assert.strictEqual(err.constructor, SyntaxError)
+    done()
   }
 
   const argv = ['./test/data/parsing-error.js']
@@ -82,25 +83,23 @@ test('should exit without error on help', t => {
   const exit = process.exit
   process.exit = sinon.spy()
 
-  t.teardown(() => {
+  t.after(() => {
     process.exit = exit
   })
 
   const argv = ['-h', 'true']
   printPlugins.printPlugins(argv)
 
-  t.ok(process.exit.called)
-  t.equal(process.exit.lastCall.args[0], undefined)
-
-  t.end()
+  t.assert.ok(process.exit.called)
+  t.assert.strictEqual(process.exit.lastCall.args[0], undefined)
 })
 
 // This test should be skipped when coverage reporting is used since outputs won't match
 test('should print plugins of server with an async/await plugin', { skip: SHOULD_SKIP }, async t => {
   const nodeMajorVersion = process.versions.node.split('.').map(x => parseInt(x, 10))[0]
   if (nodeMajorVersion < 7) {
-    t.pass('Skip because Node version < 7')
-    return t.end()
+    t.assert.ok('Skip because Node version < 7')
+    return t.assert.ok('end')
   }
 
   t.plan(3)
@@ -113,7 +112,7 @@ test('should print plugins of server with an async/await plugin', { skip: SHOULD
   const fastify = await command.printPlugins(argv)
 
   await fastify.close()
-  t.ok(spy.called)
-  t.same(spy.args[0][0], 'debug')
-  t.match(spy.args[0][1], /bound root \d+ ms\n├── bound _after \d+ ms\n├─┬ async function \(fastify, options\) { -- fastify\.get\('\/', async function \(req, reply\) { \d+ ms\n│ ├── bound _after \d+ ms\n│ └── bound _after \d+ ms\n└── bound _after \d+ ms\n/)
+  t.assert.ok(spy.called)
+  t.assert.deepStrictEqual(spy.args[0][0], 'debug')
+  t.assert.match(spy.args[0][1], /root \d+ ms\n├── bound _after \d+ ms\n├─┬ async function \(fastify, options\) { -- fastify\.get\('\/', async function \(req, reply\) { \d+ ms\n│ ├── bound _after \d+ ms\n│ └── bound _after \d+ ms\n└── bound _after \d+ ms\n/)
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

Proposal:

 - migrated `print-plugins.test.js` from `tap` to `node:test` 🔥