### PR TITLE
test: migrated print-routes.test.js to tap to node:test

### DIFF
--- a/test/print-routes.test.js
+++ b/test/print-routes.test.js
@@ -1,14 +1,13 @@
 'use strict'
 
 const proxyquire = require('proxyquire')
-const tap = require('tap')
+const { test } = require('node:test')
 const sinon = require('sinon')
 const util = require('node:util')
 const exec = util.promisify(require('node:child_process').exec)
 
 const printRoutes = require('../print-routes')
 
-const test = tap.test
 const { NYC_PROCESS_ID, NODE_V8_COVERAGE } = process.env
 const SHOULD_SKIP = NYC_PROCESS_ID || NODE_V8_COVERAGE
 
@@ -22,15 +21,15 @@ test('should print routes', async t => {
   const fastify = await command.printRoutes(['./examples/plugin.js'])
 
   await fastify.close()
-  t.ok(spy.called)
-  t.same(spy.args, [['debug', '└── / (GET, HEAD, POST)\n']])
+  t.assert.ok(spy.called)
+  t.assert.deepStrictEqual(spy.args, [['debug', '└── / (GET, HEAD, POST)\n']])
 })
 
 // This never exits in CI for some reason
 test('should print routes via cli', { skip: SHOULD_SKIP }, async t => {
   t.plan(1)
   const { stdout } = await exec('node cli.js print-routes ./examples/plugin.js', { encoding: 'utf-8', timeout: 10000 })
-  t.same(
+  t.assert.deepStrictEqual(
     stdout,
     '└── / (GET, HEAD, POST)\n\n'
   )
@@ -40,35 +39,37 @@ test('should warn on file not found', t => {
   t.plan(1)
 
   const oldStop = printRoutes.stop
-  t.teardown(() => { printRoutes.stop = oldStop })
+  t.after(() => { printRoutes.stop = oldStop })
   printRoutes.stop = function (message) {
-    t.ok(/not-found.js doesn't exist within/.test(message), message)
+    t.assert.ok(/not-found.js doesn't exist within/.test(message), message)
   }
 
   const argv = ['./data/not-found.js']
   printRoutes.printRoutes(argv)
 })
 
-test('should throw on package not found', t => {
+test('should throw on package not found', (t, done) => {
   t.plan(1)
 
   const oldStop = printRoutes.stop
-  t.teardown(() => { printRoutes.stop = oldStop })
+  t.after(() => { printRoutes.stop = oldStop })
   printRoutes.stop = function (err) {
-    t.ok(/Cannot find module 'unknown-package'/.test(err.message), err.message)
+    t.assert.ok(/Cannot find module 'unknown-package'/.test(err.message), err.message)
+    done()
   }
 
   const argv = ['./test/data/package-not-found.js']
   printRoutes.printRoutes(argv)
 })
 
-test('should throw on parsing error', t => {
+test('should throw on parsing error', (t, done) => {
   t.plan(1)
 
   const oldStop = printRoutes.stop
-  t.teardown(() => { printRoutes.stop = oldStop })
+  t.after(() => { printRoutes.stop = oldStop })
   printRoutes.stop = function (err) {
-    t.equal(err.constructor, SyntaxError)
+    t.assert.strictEqual(err.constructor, SyntaxError)
+    done()
   }
 
   const argv = ['./test/data/parsing-error.js']
@@ -79,24 +80,22 @@ test('should exit without error on help', t => {
   const exit = process.exit
   process.exit = sinon.spy()
 
-  t.teardown(() => {
+  t.after(() => {
     process.exit = exit
   })
 
   const argv = ['-h', 'true']
   printRoutes.printRoutes(argv)
 
-  t.ok(process.exit.called)
-  t.equal(process.exit.lastCall.args[0], undefined)
-
-  t.end()
+  t.assert.ok(process.exit.called)
+  t.assert.strictEqual(process.exit.lastCall.args[0], undefined)
 })
 
 test('should print routes of server with an async/await plugin', async t => {
   const nodeMajorVersion = process.versions.node.split('.').map(x => parseInt(x, 10))[0]
   if (nodeMajorVersion < 7) {
-    t.pass('Skip because Node version < 7')
-    return t.end()
+    t.assert.ok('Skip because Node version < 7')
+    return t.assert.ok('end')
   }
 
   t.plan(2)
@@ -109,8 +108,8 @@ test('should print routes of server with an async/await plugin', async t => {
   const fastify = await command.printRoutes(argv)
 
   await fastify.close()
-  t.ok(spy.called)
-  t.same(spy.args, [['debug', '└── / (GET, HEAD)\n']])
+  t.assert.ok(spy.called)
+  t.assert.deepStrictEqual(spy.args, [['debug', '└── / (GET, HEAD)\n']])
 })
 
 test('should print uncimpressed routes with --common-refix flag', async t => {
@@ -122,8 +121,8 @@ test('should print uncimpressed routes with --common-refix flag', async t => {
   })
   await command.cli(['./examples/plugin-common-prefix.js', '--commonPrefix'])
 
-  t.ok(spy.called)
-  t.same(spy.args, [['debug', '└── /\n    └── hel\n        ├── lo-world (GET, HEAD)\n        └── p (POST)\n']])
+  t.assert.ok(spy.called)
+  t.assert.deepStrictEqual(spy.args, [['debug', '└── /\n    └── hel\n        ├── lo-world (GET, HEAD)\n        └── p (POST)\n']])
 })
 
 test('should print debug safe GET routes with --method GET flag', async t => {
@@ -135,8 +134,8 @@ test('should print debug safe GET routes with --method GET flag', async t => {
   })
   await command.cli(['./examples/plugin.js', '--method', 'GET'])
 
-  t.ok(spy.called)
-  t.same(spy.args, [['debug', '└── / (GET)\n']])
+  t.assert.ok(spy.called)
+  t.assert.deepStrictEqual(spy.args, [['debug', '└── / (GET)\n']])
 })
 
 test('should print routes with hooks with --include-hooks flag', async t => {
@@ -148,6 +147,6 @@ test('should print routes with hooks with --include-hooks flag', async t => {
   })
   await command.cli(['./examples/plugin.js', '--include-hooks'])
 
-  t.ok(spy.called)
-  t.same(spy.args, [['debug', '└── / (GET, POST)\n    / (HEAD)\n    • (onSend) ["headRouteOnSendHandler()"]\n']])
+  t.assert.ok(spy.called)
+  t.assert.deepStrictEqual(spy.args, [['debug', '└── / (GET, POST)\n    / (HEAD)\n    • (onSend) ["headRouteOnSendHandler()"]\n']])
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

Proposal:

- migrated `print-routes.test.js` from `tap` to `node:test` 🔥