### PR TITLE
test: migrate esm util and helper tests to node:test

### DIFF
--- a/test/esm/util.test.js
+++ b/test/esm/util.test.js
@@ -1,16 +1,13 @@
 import { requireModule } from '../../util.js'
 import { resolve, join } from 'node:path'
-import t from 'tap'
+import { test } from 'node:test'
 import * as url from 'node:url'
-
-const test = t.test
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 
 test('requiring a commonjs module works in an esm project', (t) => {
-  t.plan(1)
   const module = requireModule(
     resolve(join(__dirname, './data/custom-logger.cjs'))
   )
-  t.strictSame(module, { name: 'Custom Logger', customLevels: { test: 99 } })
+  t.assert.deepStrictEqual(module, { name: 'Custom Logger', customLevels: { test: 99 } })
 })


### PR DESCRIPTION
Hello! I’d like to help with fastify/fastify#5555.

I noticed there are already two open PRs for graceful-shutdown.test.js and test/start.test.js, so I worked on migrating the remaining tests that weren’t covered yet.