### PR TITLE
chore: removed .taprc file

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,6 +1,0 @@
-ts: true
-jsx: false
-jobs: 1
-reporter: terse
-check-coverage: false
-timeout: 60


### PR DESCRIPTION
Proposal:

- Removed `.taprc` file, because the tests have all been converted with `node:test`