### PR TITLE
Fix command-specific --help handling

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -5,7 +5,8 @@
 const path = require('node:path')
 const commist = require('commist')()
 const { parseArgs } = require('node:util')
-const argv = parseArgs({ args: process.argv.slice(2), strict: false, allowPositionals: true }).values
+const parsedArgs = parseArgs({ args: process.argv.slice(2), strict: false, allowPositionals: true })
+const argv = parsedArgs.values
 const help = require('help-me')({
   // the default
   dir: path.join(path.dirname(require.main.filename), 'help')
@@ -32,7 +33,7 @@ commist.register('print-routes', printRoutes.cli)
 commist.register('print-plugins', printPlugins.cli)
 
 if (argv.help) {
-  const command = argv._.splice(2)[0]
+  const command = parsedArgs.positionals[0]
 
   help.toStdout(command)
 } else {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -30,6 +30,13 @@ test('--help', async t => {
   )
 })
 
+test('--help generate', async t => {
+  t.assert.equal(
+    execSync('node cli.js --help generate', { encoding: 'utf-8' }),
+    readFileSync(path.join(__dirname, '../help/generate.txt'), 'utf-8')
+  )
+})
+
 test('generate --help', async t => {
   t.assert.equal(
     execSync('node cli.js generate --help', { encoding: 'utf-8' }),


### PR DESCRIPTION
## Summary

- Fix command-specific help handling for `fastify --help <command>`
- Read command names from `parseArgs().positionals` instead of the parsed option values
- Add a regression test for `fastify --help generate`

## Validation

- `node --test test/cli.test.js`
- `npm run lint`
