### PR TITLE
fix: generate a cross-platform test command for TS ESM apps

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -64,6 +64,7 @@ const typescriptTemplate = {
   devDependencies: {
     '@types/node': cliPkg.devDependencies['@types/node'],
     c8: cliPkg.devDependencies.c8,
+    'cross-env': cliPkg.devDependencies['cross-env'],
     'ts-node': cliPkg.devDependencies['ts-node'],
     concurrently: cliPkg.devDependencies.concurrently,
     'fastify-tsconfig': cliPkg.devDependencies['fastify-tsconfig'],
@@ -168,7 +169,7 @@ function cli (args) {
       template.type = 'module'
 
       template.devDependencies.c8 = cliPkg.devDependencies.c8
-      template.scripts.test = 'npm run build:ts && tsc -p test/tsconfig.json && FASTIFY_AUTOLOAD_TYPESCRIPT=1 node --test --experimental-test-coverage --loader ts-node/esm test/**/*.ts'
+      template.scripts.test = 'npm run build:ts && tsc -p test/tsconfig.json && cross-env FASTIFY_AUTOLOAD_TYPESCRIPT=1 node --test --experimental-test-coverage --loader ts-node/esm test/**/*.ts'
       template.scripts.dev = 'fastify start -w -l info src/app.ts'
       delete template.scripts['dev:start']
     }

--- a/test/generate-typescript-esm.test.js
+++ b/test/generate-typescript-esm.test.js
@@ -21,7 +21,7 @@ const expected = {}
 const initVersion = execSync('npm get init-version').toString().trim()
 
 typescriptTemplate.type = 'module'
-typescriptTemplate.scripts.test = 'npm run build:ts && tsc -p test/tsconfig.json && FASTIFY_AUTOLOAD_TYPESCRIPT=1 node --test --experimental-test-coverage --loader ts-node/esm test/**/*.ts'
+typescriptTemplate.scripts.test = 'npm run build:ts && tsc -p test/tsconfig.json && cross-env FASTIFY_AUTOLOAD_TYPESCRIPT=1 node --test --experimental-test-coverage --loader ts-node/esm test/**/*.ts'
 
 ;(function (cb) {
   const files = []
@@ -131,7 +131,7 @@ function define (t) {
         // by default this will be ISC but since we have a MIT licensed pkg file in upper dir, npm will set the license to MIT in this case
         // so for local tests we need to accept MIT as well
         t.assert.ok(pkg.license === 'ISC' || pkg.license === 'MIT')
-        t.assert.strictEqual(pkg.scripts.test, 'npm run build:ts && tsc -p test/tsconfig.json && FASTIFY_AUTOLOAD_TYPESCRIPT=1 node --test --experimental-test-coverage --loader ts-node/esm test/**/*.ts')
+        t.assert.strictEqual(pkg.scripts.test, 'npm run build:ts && tsc -p test/tsconfig.json && cross-env FASTIFY_AUTOLOAD_TYPESCRIPT=1 node --test --experimental-test-coverage --loader ts-node/esm test/**/*.ts')
         t.assert.strictEqual(pkg.scripts.start, 'npm run build:ts && fastify start -l info dist/app.js')
         t.assert.strictEqual(pkg.scripts['build:ts'], 'tsc')
         t.assert.strictEqual(pkg.scripts['watch:ts'], 'tsc -w')
@@ -144,10 +144,11 @@ function define (t) {
         t.assert.strictEqual(pkg.dependencies['@fastify/sensible'], cliPkg.devDependencies['@fastify/sensible'])
         t.assert.strictEqual(pkg.devDependencies['@types/node'], cliPkg.devDependencies['@types/node'])
         t.assert.strictEqual(pkg.devDependencies['ts-node'], cliPkg.devDependencies['ts-node'])
+        t.assert.strictEqual(pkg.devDependencies['cross-env'], cliPkg.devDependencies['cross-env'])
         t.assert.strictEqual(pkg.devDependencies.concurrently, cliPkg.devDependencies.concurrently)
         t.assert.strictEqual(pkg.devDependencies.typescript, cliPkg.devDependencies.typescript)
 
-        const testGlob = pkg.scripts.test.split(' ', 15)[14]
+        const testGlob = pkg.scripts.test.match(/"?test\/\*\*\/\*\.ts"?$/)[0].replaceAll('"', '')
 
         t.assert.strictEqual(minimatch.match(['test/routes/plugins/more/test/here/ok.test.ts'], testGlob).length, 1)
         resolve()

--- a/test/generate-typescript.test.js
+++ b/test/generate-typescript.test.js
@@ -141,11 +141,12 @@ function define (t) {
         t.assert.strictEqual(pkg.dependencies['@fastify/sensible'], cliPkg.devDependencies['@fastify/sensible'])
         t.assert.strictEqual(pkg.devDependencies['@types/node'], cliPkg.devDependencies['@types/node'])
         t.assert.strictEqual(pkg.devDependencies.c8, cliPkg.devDependencies.c8)
+        t.assert.strictEqual(pkg.devDependencies['cross-env'], cliPkg.devDependencies['cross-env'])
         t.assert.strictEqual(pkg.devDependencies['ts-node'], cliPkg.devDependencies['ts-node'])
         t.assert.strictEqual(pkg.devDependencies.concurrently, cliPkg.devDependencies.concurrently)
         t.assert.strictEqual(pkg.devDependencies.typescript, cliPkg.devDependencies.typescript)
 
-        const testGlob = pkg.scripts.test.split(' ', 14)[13].replaceAll('"', '')
+        const testGlob = pkg.scripts.test.match(/"?test\/\*\*\/\*\.ts"?$/)[0].replaceAll('"', '')
 
         t.assert.strictEqual(minimatch.match(['test/routes/plugins/more/test/here/ok.test.ts'], testGlob).length, 1, 'should match glob')
         resolve()


### PR DESCRIPTION
## Summary
- use `cross-env` in the generated TypeScript ESM `npm test` script so the template works on Windows
- add generator assertions that the template includes `cross-env` and still preserves the expected test glob

## Problem
Issue #835 reports that generated `--lang=ts --esm` apps emit `FASTIFY_AUTOLOAD_TYPESCRIPT=1 node ...` in `package.json`, which breaks on Windows because inline environment variable assignment is shell-specific.

## Validation
- `node suite-runner.js "test/generate-typescript.test.js"`
- `node suite-runner.js "test/generate-typescript-esm.test.js"`

## Notes
- The branch was pushed via the existing SSH fork remote.
- The repo-level `npm test` command currently hits an unrelated Node 26 / `yargs` ESM failure in the existing suite.