### PR TITLE
Security: Regex Denial of Service (ReDoS) via ignore-watch option

### DIFF
--- a/lib/watch/utils.js
+++ b/lib/watch/utils.js
@@ -3,11 +3,10 @@
 const chalk = require('chalk')
 const path = require('node:path')
 
+const escapeRegExp = (str) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
 const arrayToRegExp = (arr) => {
-  const reg = arr.map((file) => {
-    if (/^\./.test(file)) { return `\\${file}` }
-    return file
-  }).join('|')
+  const reg = arr.map((file) => escapeRegExp(file)).join('|')
   return new RegExp(`(${reg})`)
 }
 


### PR DESCRIPTION
## Summary

Security: Regex Denial of Service (ReDoS) via ignore-watch option

## Problem

**Severity**: `Medium` | **File**: `lib/watch/utils.js:L5`

The `arrayToRegExp` function in `lib/watch/utils.js` constructs a regular expression from an array of strings. If a user passes specially crafted strings via the `--ignore-watch` CLI argument or the `ignoreWatch` configuration option, it can lead to catastrophic backtracking (ReDoS) and cause the application to hang.

## Solution

Escape user-supplied strings before injecting them into the RegExp constructor. You can use a library like `escape-string-regexp` or manually escape special regex characters.

## Changes

- `lib/watch/utils.js` (modified)