### PR TITLE
fix: pass logger instances via loggerInstance (fastify v5 rejects instances in `logger`)

### DIFF
--- a/start.js
+++ b/start.js
@@ -171,6 +171,13 @@ async function runFastify (args, additionalOptions, serverOptions, serverModule)
     options.trustProxy = opts.trustProxy
   }
 
+  // fastify v5 only accepts a configuration object in `logger`;
+  // logger instances must be passed via `loggerInstance`
+  if (options.logger && typeof options.logger.child === 'function') {
+    options.loggerInstance = options.logger
+    delete options.logger
+  }
+
   const fastify = Fastify(options)
 
   if (opts.prefix) {

--- a/test/data/custom-logger-instance.js
+++ b/test/data/custom-logger-instance.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const pino = require('pino')
+
+module.exports = pino({ level: 'warn' })

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -981,6 +981,17 @@ test('should support custom logger configuration in ESM', async t => {
   t.pass('server closed')
 })
 
+test('should support a logger instance from a logging module', async t => {
+  t.plan(2)
+
+  const argv = ['-L', './test/data/custom-logger-instance.js', './examples/plugin.js']
+  const fastify = await start.start(argv)
+  t.equal(fastify.log.level, 'warn')
+
+  await fastify.close()
+  t.pass('server closed')
+})
+
 test('preloading a built-in module works', async t => {
   t.plan(1)
 


### PR DESCRIPTION
## Summary

fastify v5 only accepts a configuration object in the `logger` option and throws `FST_ERR_LOG_INVALID_LOGGER_CONFIG` when given an instance — instances must go through `loggerInstance`. fastify-cli converges user-provided logger instances — from `--logging-module` (#775), `--options` files (the setup described in #574), or server options — into `options.logger`, so passing a real Pino instance crashes `fastify start` at startup:

```
FastifyError [Error]: logger options only accepts a configuration object.
    code: 'FST_ERR_LOG_INVALID_LOGGER_CONFIG'
```

This was invisible to the suite because the only logger tests use a config-object fixture (`test/data/custom-logger.js` = `{ name, customLevels: {...} }`); the instance path had zero coverage.

**Fix**: after all option merges converge in `start.js`, route any logger value exposing `child()` to `loggerInstance` (4 lines). Config-object loggers (including the existing fixtures and the `{ level }` default) are untouched.

**Regression test**: `-L` with a fixture exporting a real Pino instance; asserts the logger level survives into `fastify.log`.

## Verification

- `npm run lint` clean
- Current head is one commit based directly on `main`; it does not include #910
- Important CI caveat: `suite-runner.js` on current `main` still calls glob's removed callback API, so the green JS-suite jobs exit without running the tests. #910 fixes that runner; after it lands, this branch must be updated and the logger regression test revalidated before merge.