### PR TITLE
fix: restore yargs-parser compatible argument parsing

### DIFF
--- a/generate-plugin.js
+++ b/generate-plugin.js
@@ -6,7 +6,7 @@ const {
 } = require('node:fs').promises
 const { existsSync } = require('node:fs')
 const path = require('node:path')
-const chalk = require('chalk')
+const chalk = require('chalk').default
 const generify = require('generify')
 const parseArgs = require('./lib/parse-args')
 const cliPkg = require('./package')
@@ -69,7 +69,9 @@ async function generate (dir, template) {
   pkg.scripts = Object.assign(pkg.scripts || {}, template.scripts)
   pkg.dependencies = Object.assign(pkg.dependencies || {}, template.dependencies)
   pkg.devDependencies = Object.assign(pkg.devDependencies || {}, template.devDependencies)
-  pkg.tstyche = Object.assign(pkg.tstyche || {}, template.tstyche)
+  if (template.tstyche) {
+    pkg.tstyche = Object.assign(pkg.tstyche || {}, template.tstyche)
+  }
 
   log('debug', 'edited package.json, saving')
 

--- a/generate.js
+++ b/generate.js
@@ -6,7 +6,7 @@ const {
   existsSync
 } = require('node:fs')
 const path = require('node:path')
-const chalk = require('chalk')
+const chalk = require('chalk').default
 const generify = require('generify')
 const parseArgs = require('./lib/parse-args')
 const cliPkg = require('./package')

--- a/lib/parse-args.js
+++ b/lib/parse-args.js
@@ -20,28 +20,56 @@ function resolveEnvValue (envPrefix, optionName, type) {
   return envValue
 }
 
+const FALSY_VALUES = new Set(['false', '0'])
+const TRUTHY_VALUES = new Set(['true', '1'])
+
 // Normalize args so they work with util.parseArgs:
 // - Convert camelCase option names to kebab-case
-// - Handle --bool true -> --bool (remove value after boolean flags)
-function normalizeArgs (args, options) {
+// - Handle --bool true -> --bool and --bool false / --bool=false -> explicit false
+// - In non-strict mode, let unknown options consume the following value
+//   (--hello world -> --hello=world) to match the previous yargs-parser behavior
+function normalizeArgs (args, options, strict) {
   // Build lookup maps
   const boolKeys = new Set()
-  const allKeys = new Map() // normalized key -> config
+  const knownKeys = new Set()
+  const shortToKey = new Map()
   for (const [key, cfg] of Object.entries(options)) {
     const kebab = kebabCase(key)
-    allKeys.set(kebab, cfg)
-    allKeys.set(key, cfg)
+    knownKeys.add(kebab)
+    knownKeys.add(key)
     if (cfg.type === 'boolean') {
       boolKeys.add(kebab)
       boolKeys.add(key)
     }
+    if (cfg.short) {
+      shortToKey.set(cfg.short, kebab)
+    }
   }
 
   const normalized = []
+  // Boolean options explicitly set to false (util.parseArgs cannot express them)
+  const explicitFalse = new Set()
+
+  function pushBoolean (keyKebab, value) {
+    if (value === undefined || TRUTHY_VALUES.has(value)) {
+      normalized.push(`--${keyKebab}`)
+    } else {
+      explicitFalse.add(keyKebab)
+    }
+  }
+
   let i = 0
   while (i < args.length) {
     const arg = args[i]
     const strArg = String(arg)
+
+    // Option terminator: everything after it is passed through untouched
+    if (strArg === '--') {
+      for (; i < args.length; i++) {
+        normalized.push(String(args[i]))
+      }
+      break
+    }
 
     // Long option with = sign
     if (typeof arg === 'string' && strArg.startsWith('--') && strArg.includes('=')) {
@@ -50,58 +78,109 @@ function normalizeArgs (args, options) {
       const val = strArg.slice(eqIdx + 1)
       const keyKebab = kebabCase(key)
       if (boolKeys.has(key)) {
-        // --bool=value: drop the value, just use --bool
-        normalized.push(`--${keyKebab}`)
+        pushBoolean(keyKebab, val)
       } else {
         // --key=value with inline value
-        normalized.push(`--${keyKebab}=${String(val)}`)
+        normalized.push(`--${keyKebab}=${val}`)
       }
       i++
       continue
     }
 
     // Long option without = sign
-    if (typeof arg === 'string' && strArg.startsWith('--')) {
+    if (typeof arg === 'string' && strArg.startsWith('--') && strArg.length > 2) {
       const key = strArg.slice(2)
       const keyKebab = kebabCase(key)
+      i++
+      const next = i < args.length ? String(args[i]) : undefined
       if (boolKeys.has(key)) {
-        // Boolean flag
-        normalized.push(`--${keyKebab}`)
-        i++
-        // If next arg is a truthy/falsy value, consume it
-        if (i < args.length && ['true', 'false', '1', '0'].includes(String(args[i]))) {
+        // Boolean flag, optionally followed by an explicit true/false value
+        if (next !== undefined && (TRUTHY_VALUES.has(next) || FALSY_VALUES.has(next))) {
+          pushBoolean(keyKebab, next)
           i++
+        } else {
+          pushBoolean(keyKebab)
         }
-      } else {
+      } else if (knownKeys.has(key)) {
         // Non-boolean option: --key value
         normalized.push(`--${keyKebab}`)
-        i++
-        if (i < args.length) {
+        if (next !== undefined) {
           // Convert to string because parseArgs requires string values
-          normalized.push(String(args[i]))
+          normalized.push(next)
           i++
         }
+      } else if (!strict && next !== undefined && !next.startsWith('-')) {
+        // Unknown option followed by a value: --hello world -> --hello=world
+        normalized.push(`--${keyKebab}=${next}`)
+        i++
+      } else {
+        // Unknown option without a value
+        normalized.push(`--${keyKebab}`)
       }
       continue
     }
 
     // Short option group (-abc) or short option with value (-p 3000)
-    if (typeof arg === 'string' && strArg.startsWith('-') && strArg.length > 1) {
-      normalized.push(strArg)
+    if (typeof arg === 'string' && strArg.startsWith('-') && strArg.length > 1 && strArg !== '--') {
       i++
+      const keyKebab = strArg.length === 2 ? shortToKey.get(strArg[1]) : undefined
+      const next = i < args.length ? String(args[i]) : undefined
+      if (keyKebab !== undefined && boolKeys.has(keyKebab) &&
+        next !== undefined && (TRUTHY_VALUES.has(next) || FALSY_VALUES.has(next))) {
+        // Short boolean alias followed by an explicit true/false value
+        pushBoolean(keyKebab, next)
+        i++
+      } else {
+        normalized.push(strArg)
+      }
       continue
     }
 
     // Positional argument (convert to string)
-    normalized.push(String(arg))
+    normalized.push(strArg)
     i++
   }
 
-  return normalized
+  return { normalized, explicitFalse }
+}
+
+// Split a command line string into tokens, honoring single and double quotes
+// (yargs-parser accepted strings as well as arrays)
+function tokenizeString (str) {
+  const tokens = []
+  let current = ''
+  let quote = null
+  let hasToken = false
+  for (const ch of str) {
+    if (quote) {
+      if (ch === quote) {
+        quote = null
+      } else {
+        current += ch
+      }
+    } else if (ch === '"' || ch === "'") {
+      quote = ch
+      hasToken = true
+    } else if (/\s/.test(ch)) {
+      if (hasToken) {
+        tokens.push(current)
+        current = ''
+        hasToken = false
+      }
+    } else {
+      current += ch
+      hasToken = true
+    }
+  }
+  if (hasToken) tokens.push(current)
+  return tokens
 }
 
 function parseArgsStandard (args, config) {
   const options = config.options || {}
+  if (typeof args === 'string') {
+    args = tokenizeString(args)
+  }
 
   // Build full options map
   const fullOptions = {}
@@ -118,11 +197,14 @@ function parseArgsStandard (args, config) {
     }
   }
 
-  // Normalize args for strict parseArgs compatibility
-  const normalizedArgs = normalizeArgs(args, options)
+  // Like yargs-parser, unknown options are accepted unless explicitly requested
+  const strict = config.strict === true
+
+  // Normalize args for parseArgs compatibility
+  const { normalized: normalizedArgs, explicitFalse } = normalizeArgs(args, options, strict)
 
   const parsed = parseArgs({
-    strict: config.strict !== false,
+    strict,
     allowPositionals: true,
     tokens: config.tokenize !== false,
     options: fullOptions,
@@ -133,6 +215,26 @@ function parseArgsStandard (args, config) {
   const result = {}
   for (const [key, value] of Object.entries(parsed.values)) {
     result[camelCase(key)] = value
+  }
+  for (const key of explicitFalse) {
+    result[camelCase(key)] = false
+  }
+
+  // Repeated string options (e.g. -r a -r b) become arrays, like yargs-parser did
+  if (parsed.tokens) {
+    const repeated = new Map()
+    for (const token of parsed.tokens) {
+      if (token.kind === 'option' && token.value !== undefined) {
+        const camelKey = camelCase(token.name)
+        if (!repeated.has(camelKey)) repeated.set(camelKey, [])
+        repeated.get(camelKey).push(token.value)
+      }
+    }
+    for (const [camelKey, values] of repeated) {
+      if (values.length > 1) {
+        result[camelKey] = values
+      }
+    }
   }
 
   // Handle -- separator (rest tokens)

--- a/lib/watch/fork.js
+++ b/lib/watch/fork.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const chalk = require('chalk')
+const chalk = require('chalk').default
 const { stop, runFastify } = require('../../start')
 
 const {

--- a/lib/watch/index.js
+++ b/lib/watch/index.js
@@ -2,7 +2,7 @@
 
 const path = require('node:path')
 const cp = require('node:child_process')
-const chalk = require('chalk')
+const chalk = require('chalk').default
 const { arrayToRegExp, logWatchVerbose } = require('./utils')
 const { GRACEFUL_SHUT } = require('./constants.js')
 

--- a/lib/watch/utils.js
+++ b/lib/watch/utils.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const chalk = require('chalk')
+const chalk = require('chalk').default
 const path = require('node:path')
 
 const arrayToRegExp = (arr) => {

--- a/log.js
+++ b/log.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const chalk = require('chalk')
+const chalk = require('chalk').default
 
 const levels = {
   debug: 0,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "unit:cjs": "node suite-runner.js \"templates/app/test/**/*.test.js\"",
     "unit:esm": "node suite-runner.js \"templates/app-esm/test/**/*.test.js\"",
     "unit:ts-cjs": "cross-env TS_NODE_PROJECT=./test/configs/ts-cjs.tsconfig.json node -r ts-node/register suite-runner.js \"templates/app-ts/test/**/*.test.ts\"",
-    "unit:ts-esm": "cross-env TS_NODE_PROJECT=./test/configs/ts-esm.tsconfig.json FASTIFY_AUTOLOAD_TYPESCRIPT=1 node -r ts-node/register --loader ts-node/esm suite-runner.js \"templates/app-ts-esm/test/**/*.test.ts\"",
+    "unit:ts-esm": "cross-env TS_NODE_PROJECT=./test/configs/ts-esm.tsconfig.json FASTIFY_AUTOLOAD_TYPESCRIPT=1 node --import ./test/configs/register-ts-esm.mjs suite-runner.js \"templates/app-ts-esm/test/**/*.test.ts\"",
     "unit:suites": "node should-skip-test-suites.js || npm run all-suites",
     "all-suites": "npm run unit:cjs && npm run unit:esm && npm run unit:ts-cjs && npm run unit:ts-esm",
     "unit:cli-js-esm": "node suite-runner.js \"test/esm/**/*.test.js\"",

--- a/start.js
+++ b/start.js
@@ -4,7 +4,8 @@
 
 const { loadEnvQuitely } = require('./env-loader')
 loadEnvQuitely()
-const isDocker = require('is-docker').default
+const isDockerModule = require('is-docker')
+const isDocker = typeof isDockerModule === 'function' ? isDockerModule : isDockerModule.default
 
 const closeWithGrace = require('close-with-grace')
 const deepmerge = require('@fastify/deepmerge')({

--- a/start.js
+++ b/start.js
@@ -4,7 +4,7 @@
 
 const { loadEnvQuitely } = require('./env-loader')
 loadEnvQuitely()
-const isDocker = require('is-docker')
+const isDocker = require('is-docker').default
 
 const closeWithGrace = require('close-with-grace')
 const deepmerge = require('@fastify/deepmerge')({

--- a/suite-runner.js
+++ b/suite-runner.js
@@ -7,9 +7,9 @@ const pattern = process.argv[process.argv.length - 1]
 
 console.info(`Running tests matching ${pattern}`)
 const timeout = 10 * 60 * 1000 // 10 minutes
-glob(pattern, (err, matches) => {
-  if (err) {
-    console.error(err)
+glob(pattern, { ignore: ['**/node_modules/**', 'test/workdir*/**'] }).then((matches) => {
+  if (matches.length === 0) {
+    console.error(`No test files matched ${pattern}`)
     process.exit(1)
   }
   const resolved = matches.map(file => path.resolve(file))
@@ -19,4 +19,7 @@ glob(pattern, (err, matches) => {
     })
     .compose(spec)
   testRs.pipe(process.stdout)
+}, (err) => {
+  console.error(err)
+  process.exit(1)
 })

--- a/suite-runner.js
+++ b/suite-runner.js
@@ -13,7 +13,7 @@ glob(pattern, { ignore: ['**/node_modules/**', 'test/workdir*/**'] }).then((matc
     process.exit(1)
   }
   const resolved = matches.map(file => path.resolve(file))
-  const testRs = run({ files: resolved, timeout })
+  const testRs = run({ files: resolved, timeout, concurrency: 1 })
     .on('test:fail', () => {
       process.exitCode = 1
     })

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -293,7 +293,7 @@ test('should parse custom plugin options', t => {
       a: true,
       b: true,
       c: true,
-      hello: true
+      hello: 'world'
     },
     bodyLimit: 5242880,
     debug: true,
@@ -489,4 +489,72 @@ test('should favor trust proxy ips over trust proxy hop', t => {
     includeHooks: undefined,
     trustProxy: '127.0.0.1'
   })
+})
+
+test('should treat explicit false boolean values as false', t => {
+  t.plan(8)
+
+  const parsedArgs = parseArgs([
+    '--watch=false',
+    '--debug', 'false',
+    '--pretty-logs', '0',
+    '-P', 'false',
+    '--options=1',
+    '--verbose-watch', 'true',
+    'app.js'
+  ])
+
+  t.assert.strictEqual(parsedArgs.watch, false)
+  t.assert.strictEqual(parsedArgs.debug, false)
+  t.assert.strictEqual(parsedArgs.prettyLogs, false)
+  t.assert.strictEqual(parsedArgs.options, true)
+  t.assert.strictEqual(parsedArgs.verboseWatch, true)
+  t.assert.deepStrictEqual(parsedArgs._, ['app.js'])
+  t.assert.deepStrictEqual(parsedArgs['--'], [])
+  t.assert.deepStrictEqual(parsedArgs.pluginOptions, {})
+})
+
+test('should accept unknown options like yargs-parser did', t => {
+  t.plan(3)
+
+  const parsedArgs = parseArgs(['--yaml=true', '--custom', 'value', 'app.js'])
+
+  t.assert.deepStrictEqual(parsedArgs._, ['app.js'])
+  t.assert.strictEqual(parsedArgs.watch, false)
+  t.assert.strictEqual(parsedArgs.help, undefined)
+})
+
+test('should preserve plugin option values', t => {
+  t.plan(2)
+
+  const parsedArgs = parseArgs(['app.js', '--', '--hello', 'world', '--flag', '--foo=bar', '-abc', 'positional'])
+
+  t.assert.deepStrictEqual(parsedArgs.pluginOptions, {
+    hello: 'world',
+    flag: true,
+    foo: 'bar',
+    a: true,
+    b: true,
+    c: true
+  })
+  t.assert.deepStrictEqual(parsedArgs['--'], ['--hello', 'world', '--flag', '--foo=bar', '-abc', 'positional'])
+})
+
+test('should accept a string of arguments', t => {
+  t.plan(3)
+
+  const parsedArgs = parseArgs('--port 7777 --watch=false "./my app.js" -- --hello world')
+
+  t.assert.strictEqual(parsedArgs.port, 7777)
+  t.assert.strictEqual(parsedArgs.watch, false)
+  t.assert.deepStrictEqual(parsedArgs._, ['./my app.js'])
+})
+
+test('should collect repeated options into an array', t => {
+  t.plan(2)
+
+  const parsedArgs = parseArgs(['-r', './a.js', '--require', './b.js', '--import', './c.mjs', 'app.js'])
+
+  t.assert.deepStrictEqual(parsedArgs.require, ['./a.js', './b.js'])
+  t.assert.strictEqual(parsedArgs.import, './c.mjs')
 })

--- a/test/configs/register-ts-esm.mjs
+++ b/test/configs/register-ts-esm.mjs
@@ -1,0 +1,6 @@
+// Registers the ts-node ESM loader via module.register(), which replaces the
+// deprecated --loader flag. Node 24 fails to run test files with --loader.
+import { register } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+register('ts-node/esm', pathToFileURL('./'))

--- a/test/configs/ts-cjs.tsconfig.json
+++ b/test/configs/ts-cjs.tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../node_modules/fastify-tsconfig/tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "sourceMap": true
+    "sourceMap": true,
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"]
 }

--- a/test/configs/ts-esm.tsconfig.json
+++ b/test/configs/ts-esm.tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "NodeNext",
     "module": "NodeNext",
     "target": "ES2022",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"]
 }

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -610,7 +610,7 @@ test('should start the server listening on 0.0.0.0 when running in docker', asyn
   isDocker.returns(true)
 
   const start = proxyquire('../start', {
-    'is-docker': isDocker
+    'is-docker': { default: isDocker }
   })
 
   const argv = ['-p', getPort(), './examples/plugin.js']
@@ -848,7 +848,7 @@ for (const inspectorHostCase of inspectorHostCases) {
     const isDocker = sinon.stub().returns(inspectorHostCase.isDocker)
     const isKubernetes = sinon.stub().returns(inspectorHostCase.isKubernetes)
     const start = proxyquire('../start', {
-      'is-docker': isDocker,
+      'is-docker': { default: isDocker },
       './util': {
         ...require('../util'),
         isKubernetes

--- a/util.js
+++ b/util.js
@@ -4,7 +4,7 @@ const fs = require('node:fs')
 const path = require('node:path')
 const url = require('node:url')
 const semver = require('semver')
-const pkgUp = require('pkg-up')
+const { pkgUp } = require('pkg-up')
 const resolveFrom = require('resolve-from')
 
 const moduleSupport = semver.satisfies(process.version, '>= 14 || >= 12.17.0 < 13.0.0')


### PR DESCRIPTION
Proposal:

The migration to `util.parseArgs` (f2738f5) dropped several behaviors of yargs-parser:

- unknown options threw `Unknown option` — the parser is now non-strict by default (`strict` only when explicitly `true`), like yargs-parser. `generate-swagger`, `eject`, etc. pass through the main `args.js` parser with options it does not know (`--yaml=true`).
- unknown options did not consume their value (`--hello world` → `hello: true`). Now `hello: 'world'`; a value starting with `-` is still treated as a flag.
- booleans could not be set to `false`: `--watch=false`, `--watch false`, `--watch 0`, `-w false` are now honored. `util.parseArgs` cannot express `--bool=false`, so the normalizer collects them and applies them after parsing.
- everything after `--` was being re-normalized; it is now passed through untouched, so `'--'` and plugin options match the input.
- repeated string options (`-r a -r b`, `--import`) kept only the last value; `start.js` then crashed with `opts.require.forEach is not a function`. They are collected into arrays again from `tokens`.
- a string argv is accepted again (with a quote-aware tokenizer); `helper.build('./plugin.js -- --hello world')` relied on it.
- `test/args.test.js` restores `hello: 'world'` (the migration commit had changed the expectation to `hello: true`) and adds tests for each case above.

Test runner:

`suite-runner.js` never ran a single test: `glob` was bumped to v13 (#789) and the callback API no longer exists, so `glob(pattern, cb)` resolved a promise nobody awaited and the process exited 0. That is why CI stayed green through the regressions above. The runner now awaits the promise, exits 1 when no file matches, and ignores `node_modules` and the `test/workdir*` directories left behind by the generate tests.

With tests actually running, two more environment issues showed up:

- `pkg-up@5`, `is-docker@4` and `chalk@6` (bumped in #896) are ESM-only. They are loaded through `require(esm)` (`.default` / named export); the `is-docker` mocks in `test/start.test.js` are adjusted accordingly. Note: this requires Node ≥ 22.12 — if Node 20 must still be supported, these three dependencies need to be pinned to their CJS versions instead.
- TypeScript 6 no longer includes every `@types/*` automatically: `types: ["node"]` is added to the two test tsconfigs.
- `unit:ts-esm` fails on Node 24 with `--loader ts-node/esm` when `run()` spawns the test files; it now uses `module.register()` via `--import ./test/configs/register-ts-esm.mjs`, which also removes the `ExperimentalWarning`.

Also: `generate-plugin.js` no longer writes an empty `tstyche: {}` when the template has none.

Note:

- I'm also preparing a separate PR to ensure 100% tests coverage 🔥
- Supersedes #914: the `concurrency: 1` runner setting and the version-tolerant `is-docker` import come from there (co-authored with @mcollina).

Closes #912