### PR TITLE
fix: make the test runner execute the full suite

### DIFF
--- a/args.js
+++ b/args.js
@@ -51,6 +51,7 @@ const CLI_OPTIONS = {
   'common-prefix': { type: 'boolean' },
   'include-hooks': { type: 'boolean' },
   'trust-proxy-enabled': { type: 'boolean' },
+  yaml: { type: 'boolean' },
   help: { type: 'boolean', short: 'h' },
   'debug-port': { type: 'string', short: 'I' }
 }

--- a/suite-runner.js
+++ b/suite-runner.js
@@ -5,21 +5,40 @@ const { glob } = require('glob')
 
 const pattern = process.argv[process.argv.length - 1]
 
-console.info(`Running tests matching ${pattern}`)
-const timeout = 10 * 60 * 1000 // 10 minutes
-glob(pattern, { ignore: ['**/node_modules/**', 'test/workdir*/**'] }).then((matches) => {
+async function main () {
+  console.info(`Running tests matching ${pattern}`)
+  const timeout = 10 * 60 * 1000 // 10 minutes
+  const matches = await glob(pattern, {
+    ignore: ['**/node_modules/**', 'test/workdir*/**']
+  })
   if (matches.length === 0) {
-    console.error(`No test files matched ${pattern}`)
-    process.exit(1)
+    throw new Error(`No test files matched ${pattern}`)
   }
+
   const resolved = matches.map(file => path.resolve(file))
-  const testRs = run({ files: resolved, timeout, concurrency: 1 })
+  const runOptions = {
+    files: resolved,
+    timeout,
+    concurrency: 1
+  }
+  if (pattern.endsWith('.ts') && process.execArgv.some(arg => arg.includes('ts-node/esm'))) {
+    runOptions.isolation = 'none'
+  }
+
+  const testRs = run(runOptions)
     .on('test:fail', () => {
       process.exitCode = 1
     })
     .compose(spec)
-  testRs.pipe(process.stdout)
-}, (err) => {
+
+  await new Promise((resolve, reject) => {
+    testRs.once('error', reject)
+    testRs.once('end', resolve)
+    testRs.pipe(process.stdout, { end: false })
+  })
+}
+
+main().catch(err => {
   console.error(err)
-  process.exit(1)
+  process.exitCode = 1
 })

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -210,6 +210,18 @@ test('should parse env vars correctly', t => {
   })
 })
 
+test('should preserve explicit false boolean values', t => {
+  const parsedArgs = parseArgs([
+    '--watch=false',
+    '--pretty-logs', 'false',
+    'app.js'
+  ])
+
+  t.assert.strictEqual(parsedArgs.watch, false)
+  t.assert.strictEqual(parsedArgs.prettyLogs, false)
+  t.assert.deepStrictEqual(parsedArgs._, ['app.js'])
+})
+
 test('should respect default values', t => {
   t.plan(14)
 


### PR DESCRIPTION
Keep the test runner from silently skipping or terminating before tests complete after the glob upgrade.

The runner now awaits glob and test completion, fails on unmatched patterns, serializes shared-fixture tests, and uses in-process execution for the TypeScript ESM suite. This also allows the existing generate-swagger --yaml option through global argument parsing and adds explicit boolean false coverage.

Verified with npm test and npm run lint.
